### PR TITLE
Bugfix/set location in deployment

### DIFF
--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -112,7 +112,7 @@ module Azure
         validate_deployment_params(params, options)
         options[:deployment_name] ||= options[:cloud_service_name]
         Loggerx.info 'Creating deploymnent...'
-        options[:cloud_service_name] ||= generate_cloud_service_name(params[:vm_name])        
+        options[:cloud_service_name] ||= generate_cloud_service_name(params[:vm_name])
         optionals = {}
         if options[:virtual_network_name]
           virtual_network_service = Azure::VirtualNetworkManagementService.new

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -122,7 +122,7 @@ module Azure
           else
             vnet = virtual_networks.first
             if !vnet.affinity_group.empty?
-              options[:affinity_group_name] = vnet.affinity_group
+              optionals[:affinity_group_name] = vnet.affinity_group
             else
               optionals[:location] = vnet.location
             end


### PR DESCRIPTION
There is a bug when trying to create a server and and affinity group is set, the options sent to the storage creations are not properly set (a typo I think) in the mainstream code this is ok, so I bet it was a regression.
