### PR TITLE
do not pollute root namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ nbproject/*
 
 
 .DS_Store
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ relay2.requires_client_authorization = false
 relay2 = azure_service_bus.create_relay(relay2)
 
 # Delete a relay endpoint
-azure_service_bus.delete_relay("test-relay2")
+azure_service_bus.delete_relay("test-relay2")```
 
 ### Queues
 
@@ -319,6 +319,7 @@ azure_service_bus.delete_queue_message(message)
 # Delete a queue
 azure_service_bus.delete_queue("test-queue-1")
 ```
+
 ### Topics
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ relay2.requires_client_authorization = false
 relay2 = azure_service_bus.create_relay(relay2)
 
 # Delete a relay endpoint
-azure_service_bus.delete_relay("test-relay2")```
+azure_service_bus.delete_relay("test-relay2")
+```
 
 ### Queues
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ options = {
   :virtual_network_name => 'xplattestvnet',
   :subnet_name => 'subnet1',
   :availability_set_name => 'availabiltyset1'
+  :reserved_ip_name => 'reservedipname'
 }
 virtual_machine_service.create_virtual_machine(params,options)
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ options = {
   :private_key_file => 'c:/private_key.key', #required for ssh or winrm(https) certificate.
   :certificate_file => 'c:/certificate.pem', #required for ssh or winrm(https) certificate.
   :ssh_port => 2222,
-  :vm_size => 'Small', #valid choices are (ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4)
+  :vm_size => 'Small', #valid choices are (Basic_A0,Basic_A1,Basic_A2,Basic_A3,Basic_A4,ExtraSmall,Small,Medium,Large,ExtraLarge,A5,A6,A7,A8,A9,Standard_D1,Standard_D2,Standard_D3,Standard_D4,Standard_D11,Standard_D12,Standard_D13,Standard_D14,Standard_DS1,Standard_DS2,Standard_DS3,Standard_DS4,Standard_DS11,Standard_DS12,Standard_DS13,Standard_DS14,Standard_G1,Standard_G2,Standard_G3,Standard_G4,Standard_G5)
   :affinity_group_name => 'affinity1',
   :virtual_network_name => 'xplattestvnet',
   :subnet_name => 'subnet1',
@@ -471,7 +471,7 @@ options = {
   :certificate_file => 'c:/certificate.pem', #required for ssh or winrm(https) certificate.
   :winrm_https_port => 5999,
   :winrm_http_port => 6999, #Used to open different powershell port
-  :vm_size => 'Small', #valid choices are (ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4)
+  :vm_size => 'Small', #valid choices are (Basic_A0,Basic_A1,Basic_A2,Basic_A3,Basic_A4,ExtraSmall,Small,Medium,Large,ExtraLarge,A5,A6,A7,A8,A9,Standard_D1,Standard_D2,Standard_D3,Standard_D4,Standard_D11,Standard_D12,Standard_D13,Standard_D14,Standard_DS1,Standard_DS2,Standard_DS3,Standard_DS4,Standard_DS11,Standard_DS12,Standard_DS13,Standard_DS14,Standard_G1,Standard_G2,Standard_G3,Standard_G4,Standard_G5)
   :availability_set_name => 'availabiltyset'
 }
 virtual_machine_service.add_role(params, options)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,28 @@ azure_queue_service.delete_queue("test-queue")
 ```
 ## Service Bus
 
+### Relay
+
+```ruby
+# Require the azure rubygem
+require "azure"
+
+# Create an azure service bus object
+azure_service_bus = Azure::ServiceBusService.new
+
+# Create a relay endpoint with just the endpoint name
+relay1 = azure_service_bus.create_relay("test-relay-1", { :relay_type => "Http" })
+
+# Create a relay endpoint with a relay object
+relay2 = Azure::ServiceBus::Relay.new("test-relay-2")
+relay2.requires_client_authorization = false
+relay2 = azure_service_bus.create_relay(relay2)
+
+# Delete a relay endpoint
+azure_service_bus.delete_relay("test-relay2")
+
+### Queues
+
 ```ruby
 # Require the azure rubygem
 require "azure"

--- a/Rakefile
+++ b/Rakefile
@@ -24,16 +24,16 @@ end
 namespace :test do
   task :require_environment do
     unset_environment = [
-      #ENV.fetch("AZURE_STORAGE_ACCOUNT",  nil),
-      #ENV.fetch("AZURE_STORAGE_ACCESS_KEY",    nil),
+      ENV.fetch("AZURE_STORAGE_ACCOUNT",  nil),
+      ENV.fetch("AZURE_STORAGE_ACCESS_KEY",    nil),
       # ENV.fetch("AZURE_STORAGE_TABLE_HOST",    nil),
       # ENV.fetch("AZURE_STORAGE_BLOB_HOST",     nil),
       # ENV.fetch("AZURE_STORAGE_QUEUE_HOST",    nil),
-      ENV.fetch("AZURE_SERVICEBUS_NAMESPACE", "bwalks"),
-      ENV.fetch("AZURE_SERVICEBUS_ACCESS_KEY", "/K6nD6rhBPYn05dynh7Agg/X7t0CXICX6J0su05u6ho="),
+      ENV.fetch("AZURE_SERVICEBUS_NAMESPACE", nil),
+      ENV.fetch("AZURE_SERVICEBUS_ACCESS_KEY", nil),
       # ENV.fetch("AZURE_SERVICEBUS_ISSUER",     nil)
-      #ENV.fetch('AZURE_MANAGEMENT_CERTIFICATE', nil),
-      #ENV.fetch('AZURE_SUBSCRIPTION_ID', nil)
+      ENV.fetch('AZURE_MANAGEMENT_CERTIFICATE', nil),
+      ENV.fetch('AZURE_SUBSCRIPTION_ID', nil)
     ].include?(nil)
 
     abort "[ABORTING] Configure your environment to run the integration tests" if unset_environment

--- a/Rakefile
+++ b/Rakefile
@@ -24,16 +24,16 @@ end
 namespace :test do
   task :require_environment do
     unset_environment = [
-      ENV.fetch("AZURE_STORAGE_ACCOUNT",  nil),
-      ENV.fetch("AZURE_STORAGE_ACCESS_KEY",    nil),
+      #ENV.fetch("AZURE_STORAGE_ACCOUNT",  nil),
+      #ENV.fetch("AZURE_STORAGE_ACCESS_KEY",    nil),
       # ENV.fetch("AZURE_STORAGE_TABLE_HOST",    nil),
       # ENV.fetch("AZURE_STORAGE_BLOB_HOST",     nil),
       # ENV.fetch("AZURE_STORAGE_QUEUE_HOST",    nil),
-      ENV.fetch("AZURE_SERVICEBUS_NAMESPACE", nil),
-      ENV.fetch("AZURE_SERVICEBUS_ACCESS_KEY", nil),
+      ENV.fetch("AZURE_SERVICEBUS_NAMESPACE", "bwalks"),
+      ENV.fetch("AZURE_SERVICEBUS_ACCESS_KEY", "/K6nD6rhBPYn05dynh7Agg/X7t0CXICX6J0su05u6ho="),
       # ENV.fetch("AZURE_SERVICEBUS_ISSUER",     nil)
-      ENV.fetch('AZURE_MANAGEMENT_CERTIFICATE', nil),
-      ENV.fetch('AZURE_SUBSCRIPTION_ID', nil)
+      #ENV.fetch('AZURE_MANAGEMENT_CERTIFICATE', nil),
+      #ENV.fetch('AZURE_SUBSCRIPTION_ID', nil)
     ].include?(nil)
 
     abort "[ABORTING] Configure your environment to run the integration tests" if unset_environment

--- a/azure.gemspec
+++ b/azure.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest", "~> 3.0")
   s.add_development_dependency('mocha', '~> 1.0')
   s.add_development_dependency('turn', '~> 0.9')
+  s.add_development_dependency('timecop', '~> 0.7')
 end

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -23,7 +23,7 @@ require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
 include Azure::Core::Utility
-Loggerx = Azure::Core::Logger
+Azure::Loggerx = Azure::Core::Logger
 
 module Azure
   module BaseManagement
@@ -131,7 +131,7 @@ module Azure
           request_path = '/affinitygroups'
           request = ManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Loggerx.info "Affinity Group #{name} is created."
+          Azure::Loggerx.info "Affinity Group #{name} is created."
         end
       end
 
@@ -160,7 +160,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:put, request_path, body)
           request.call
-          Loggerx.info "Affinity Group #{name} is updated."
+          Azure::Loggerx.info "Affinity Group #{name} is updated."
         end
       end
 
@@ -178,7 +178,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted affinity group #{name}."
+          Azure::Loggerx.info "Deleted affinity group #{name}."
         end
       end
 

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -22,7 +22,6 @@ require 'azure/base_management/serialization'
 require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
-include Azure::Core::Utility
 Azure::Loggerx = Azure::Core::Logger
 
 module Azure

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -22,7 +22,6 @@ require 'azure/base_management/serialization'
 require 'azure/base_management/location'
 require 'azure/base_management/affinity_group'
 
-include Azure::BaseManagement
 include Azure::Core::Utility
 Loggerx = Azure::Core::Logger
 

--- a/lib/azure/base_management/base_management_service.rb
+++ b/lib/azure/base_management/base_management_service.rb
@@ -130,7 +130,7 @@ module Azure
           request_path = '/affinitygroups'
           request = ManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Azure::Loggerx.info "Affinity Group #{name} is created."
+          Loggerx.info "Affinity Group #{name} is created."
         end
       end
 
@@ -159,7 +159,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:put, request_path, body)
           request.call
-          Azure::Loggerx.info "Affinity Group #{name} is updated."
+          Loggerx.info "Affinity Group #{name} is updated."
         end
       end
 
@@ -177,7 +177,7 @@ module Azure
           request_path = "/affinitygroups/#{name}"
           request = ManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted affinity group #{name}."
+          Loggerx.info "Deleted affinity group #{name}."
         end
       end
 

--- a/lib/azure/base_management/management_http_request.rb
+++ b/lib/azure/base_management/management_http_request.rb
@@ -66,7 +66,7 @@ module Azure
       def wait_for_completion(response)
         ret_val = Nokogiri::XML response.body
         if ret_val.at_css('Error Code') && ret_val.at_css('Error Code').content == 'AuthenticationFailed'
-          Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         end
         if response.status_code.to_i == 200 || response.status_code.to_i == 201
           return response
@@ -75,15 +75,15 @@ module Azure
         elsif response.status_code.to_i > 201 && response.status_code.to_i <= 299
           check_completion(response.headers['x-ms-request-id'])
         elsif warn && !response.success?
-          # Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          # Azure::Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         elsif response.body
           if ret_val.at_css('Error Code') && ret_val.at_css('Error Message')
-            Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+            Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
           else
-            Loggerx.exception_message "http error: #{response.status_code}"
+            Azure::Loggerx.exception_message "http error: #{response.status_code}"
           end
         else
-          Loggerx.exception_message "http error: #{response.status_code}"
+          Azure::Loggerx.exception_message "http error: #{response.status_code}"
         end
       end
 
@@ -122,9 +122,9 @@ module Azure
             if status.downcase != 'succeeded'
               error_code = xml_content(ret_val, 'Operation Error Code')
               error_msg = xml_content(ret_val, 'Operation Error Message')
-              Loggerx.exception_message "#{error_code}: #{error_msg}"
+              Azure::Loggerx.exception_message "#{error_code}: #{error_msg}"
             else
-              Loggerx.success "#{status.downcase} (#{status_code})"
+              Azure::Loggerx.success "#{status.downcase} (#{status_code})"
             end
             return
           else

--- a/lib/azure/base_management/management_http_request.rb
+++ b/lib/azure/base_management/management_http_request.rb
@@ -66,7 +66,7 @@ module Azure
       def wait_for_completion(response)
         ret_val = Nokogiri::XML response.body
         if ret_val.at_css('Error Code') && ret_val.at_css('Error Code').content == 'AuthenticationFailed'
-          Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         end
         if response.status_code.to_i == 200 || response.status_code.to_i == 201
           return response
@@ -75,15 +75,15 @@ module Azure
         elsif response.status_code.to_i > 201 && response.status_code.to_i <= 299
           check_completion(response.headers['x-ms-request-id'])
         elsif warn && !response.success?
-          # Azure::Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+          # Loggerx.warn ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
         elsif response.body
           if ret_val.at_css('Error Code') && ret_val.at_css('Error Message')
-            Azure::Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
+            Loggerx.error_with_exit ret_val.at_css('Error Code').content + ' : ' + ret_val.at_css('Error Message').content
           else
-            Azure::Loggerx.exception_message "http error: #{response.status_code}"
+            Loggerx.exception_message "http error: #{response.status_code}"
           end
         else
-          Azure::Loggerx.exception_message "http error: #{response.status_code}"
+          Loggerx.exception_message "http error: #{response.status_code}"
         end
       end
 
@@ -122,9 +122,9 @@ module Azure
             if status.downcase != 'succeeded'
               error_code = xml_content(ret_val, 'Operation Error Code')
               error_msg = xml_content(ret_val, 'Operation Error Message')
-              Azure::Loggerx.exception_message "#{error_code}: #{error_msg}"
+              Loggerx.exception_message "#{error_code}: #{error_msg}"
             else
-              Azure::Loggerx.success "#{status.downcase} (#{status_code})"
+              Loggerx.success "#{status.downcase} (#{status_code})"
             end
             return
           else

--- a/lib/azure/base_management/serialization.rb
+++ b/lib/azure/base_management/serialization.rb
@@ -16,6 +16,7 @@
 module Azure
   module BaseManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.locations_from_xml(locationXML)
         location_objs = []
         xml = locationXML.css('Locations Location')

--- a/lib/azure/blob/auth/shared_access_signature.rb
+++ b/lib/azure/blob/auth/shared_access_signature.rb
@@ -56,7 +56,7 @@ module Azure
         # ==== Attributes
         #
         # * +path+         - the container or blob path
-        # * +options+      - Hash. Optional parameters
+        # * +options+      - Hash. Required and optional parameters
         # * +account_name+ - The account name. Defaults to the one in the
         #                    global configuration.
         # * +access_key+   - The access_key encoded in Base64. Defaults to the
@@ -64,9 +64,10 @@ module Azure
         #
         # ==== Options
         #
+        # * +:resource+     - String. Resource type, either 'b' (blob) or 'c' (container). Default 'b'
         # * +:permissions+  - String. Combination of 'r','w','d','l' (container only) in this order. Default 'r'
-        # * +:start+        - String. Date/Time in ISO8601 format. Optional.
-        # * +:expiry+       - String. Date/Time in ISO8601 format. Required.
+        # * +:start+        - String. UTC Date/Time in ISO8601 format. Optional.
+        # * +:expiry+       - String. UTC Date/Time in ISO8601 format. Required.
         # * +:identifier+   - String. Identifier for stored access policy. Optional
         # * +:version+      - String. API version. Default '2013-08-15'
         #
@@ -75,7 +76,7 @@ module Azure
         # * +:content_encoding    - String. Response header override. Optional.
         # * +:content_language    - String. Response header override. Optional.
         # * +:content_type        - String. Response header override. Optional.
-        def initialize(path='/', options={}, account_name=Azure.config.storage_account_name, access_key=Azure.config.storage_access_key)
+        def initialize(path, options, account_name=Azure.config.storage_account_name, access_key=Azure.config.storage_access_key)
           @path = path
           @account_name = account_name
           @options = DEFAULTS.merge(options)

--- a/lib/azure/blob/auth/shared_access_signature.rb
+++ b/lib/azure/blob/auth/shared_access_signature.rb
@@ -1,0 +1,138 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+
+# TODO: add expected commenting
+# TODO: extract common SAS logic, add support for the other SAS types
+# TODO: tests
+# TODO: can the empty strings be safely removed?
+
+require "azure/core/configuration"
+require "azure/core/auth/signer"
+
+# This will break if used against API version prior to 2013-08-15 as the format
+# changed
+# See https://msdn.microsoft.com/library/azure/dn140255.aspx for more information on construction
+module Azure
+  module Blob
+    module Auth
+      class SharedAccessSignature < Core::Auth::Signer
+        DEFAULTS = {
+          path: '/',
+          resource: 'b',
+          permissions: 'r',
+          start: '',
+          expiry: '',
+          identifier: '',
+          version: '2013-08-15',
+          cache_control: '',
+          content_disposition: '',
+          content_encoding: '',
+          content_language: '',
+          content_type: ''
+        }
+
+        MAPPINGS = {
+          sp: :permissions,
+          st: :start,
+          se: :expiry,
+          sr: :resource,
+          si: :identifier,
+
+          sv: :version,
+
+          rscc: :cache_control,
+          rscd: :content_disposition,
+          rsce: :content_encoding,
+          rscl: :content_language,
+          rsct: :content_type
+        }
+
+        OPTIONAL_QUERY_PARAMS = [:sp, :si, :rscc, :rscd, :rsce, :rscl, :rsct]
+
+        # The Azure account's name.
+        attr :account_name
+        attr :options
+
+        # Public: Initialize the Signer.
+        #
+        # account_name - The account name. Defaults to the one in the
+        #                global configuration.
+        # access_key   - The access_key encoded in Base64. Defaults to the
+        #                one in the global configuration.
+        def initialize(options={}, account_name=Azure.config.storage_account_name, access_key=Azure.config.storage_access_key)
+          @account_name = account_name
+          @options = DEFAULTS.merge(options)
+
+          super(access_key)
+        end
+
+        def signable_string
+          [
+            options[:permissions],
+            options[:start],
+            options[:expiry],
+            canonicalized_resource,
+            options[:identifier],
+
+            options[:version],
+
+            options[:cache_control],
+            options[:content_disposition],
+            options[:content_encoding],
+            options[:content_language],
+            options[:content_type]
+          ].join("\n")
+        end
+
+        def canonicalized_path
+          # Note: 'c' is planned to become 'container' in a forthcoming API update
+          if options[:resource].first == 'c' then
+            # If resource is a container, remove the last part (which is the filename)
+            options[:path].split('/').reverse.drop(1).reverse.join('/')
+          else
+            options[:path]
+          end
+        end
+
+        def canonicalized_resource
+          "/#{account_name}/#{canonicalized_path}"
+        end
+
+        def signature
+          sign(signable_string)
+        end
+
+        def query_hash
+          Hash[MAPPINGS.map { |query_key, friendly_key|
+            [query_key, URI.unescape(options[friendly_key])]
+          }].reject { |k,v|
+            OPTIONAL_QUERY_PARAMS.include?(k) && v == ''
+          }.merge(sig: URI.unescape(signature))
+        end
+
+        def signed_uri
+          uri  = Addressable::URI.new
+          uri.query_values = query_hash
+          "https://#{account_name}.blob.core.windows.net/#{options[:path]}?#{uri.query}"
+        end
+
+        def to_s
+          signed_uri
+        end
+
+      end
+    end
+  end
+end

--- a/lib/azure/blob/blob_service.rb
+++ b/lib/azure/blob/blob_service.rb
@@ -14,6 +14,7 @@
 #--------------------------------------------------------------------------
 require 'azure/service/storage_service'
 require 'azure/blob/serialization'
+require 'azure/blob/auth/shared_access_signature'
 require 'base64'
 
 module Azure
@@ -29,25 +30,25 @@ module Azure
       #
       # ==== Attributes
       #
-      # * +options+       - Hash. Optional parameters. 
+      # * +options+       - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:prefix+       - String. Filters the results to return only containers 
+      # * +:prefix+       - String. Filters the results to return only containers
       #   whose name begins with the specified prefix. (optional)
       #
-      # * +:marker+       - String. An identifier the specifies the portion of the 
+      # * +:marker+       - String. An identifier the specifies the portion of the
       #   list to be returned. This value comes from the property
-      #   Azure::Service::EnumerationResults.continuation_token when there 
-      #   are more containers available than were returned. The 
+      #   Azure::Service::EnumerationResults.continuation_token when there
+      #   are more containers available than were returned. The
       #   marker value may then be used here to request the next set
       #   of list items. (optional)
       #
-      # * +:max_results+  - Integer. Specifies the maximum number of containers to return. 
-      #   If max_results is not specified, or is a value greater than 
-      #   5,000, the server will return up to 5,000 items. If it is set 
-      #   to a value less than or equal to zero, the server will return 
+      # * +:max_results+  - Integer. Specifies the maximum number of containers to return.
+      #   If max_results is not specified, or is a value greater than
+      #   5,000, the server will return up to 5,000 items. If it is set
+      #   to a value less than or equal to zero, the server will return
       #   status code 400 (Bad Request). (optional)
       #
       # * +:metadata+     - Boolean. Specifies whether or not to return the container metadata.
@@ -56,16 +57,16 @@ module Azure
       # * +:timeout+      - Integer. A timeout in seconds.
       #
       # NOTE: Metadata requested with the :metadata parameter must have been stored in
-      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob 
-      # service. Beginning with that version, all metadata names must adhere to the naming 
+      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob
+      # service. Beginning with that version, all metadata names must adhere to the naming
       # conventions for C# identifiers.
       #
-      # See: http://msdn.microsoft.com/en-us/library/aa664670(VS.71).aspx 
+      # See: http://msdn.microsoft.com/en-us/library/aa664670(VS.71).aspx
       #
-      # Any metadata with invalid names which were previously stored, will be returned with the 
+      # Any metadata with invalid names which were previously stored, will be returned with the
       # key "x-ms-invalid-name" in the metadata hash. This may contain multiple values and be an
       # Array (vs a String if it only contains a single value).
-      # 
+      #
       # Returns an Azure::Service::EnumerationResults
       def list_containers(options={})
         query = { }
@@ -76,19 +77,19 @@ module Azure
           query["include"] = "metadata" if options[:metadata] == true
           query["timeout"] = options[:timeout].to_s if options[:timeout]
         end
-        
+
         uri = containers_uri(query)
         response = call(:get, uri)
 
         Serialization.container_enumeration_results_from_xml(response.body)
       end
 
-      # Public: Create a new container 
+      # Public: Create a new container
       #
       # ==== Attributes
       #
       # * +name+          - String. The name of the container
-      # * +options+       - Hash. Optional parameters. 
+      # * +options+       - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -125,7 +126,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -148,7 +149,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -174,7 +175,7 @@ module Azure
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -195,13 +196,13 @@ module Azure
         container
       end
 
-      # Public: Gets the access control list (ACL) and any container-level access policies 
+      # Public: Gets the access control list (ACL) and any container-level access policies
       # for the container.
       #
       # ==== Attributes
       #
       # * +name+       - String. The name of the container
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+    - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -234,14 +235,14 @@ module Azure
       #
       # * +name+                         - String. The name of the container
       # * +public_access_level+          - String. The container public access level
-      # * +options+                      - Hash. Optional parameters. 
+      # * +options+                      - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:signed_identifiers+          - Array. A list of Azure::Entity::SignedIdentifier instances (optional) 
+      # * +:signed_identifiers+          - Array. A list of Azure::Entity::SignedIdentifier instances (optional)
       # * +:timeout+                     - Integer. A timeout in seconds.
-      # 
+      #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179391.aspx
       #
       # Returns a tuple of (container, signed_identifiers)
@@ -278,7 +279,7 @@ module Azure
       #
       # * +name+      - String. The name of the container
       # * +metadata+  - Hash. A Hash of the metadata values
-      # * +options+   - Hash. Optional parameters. 
+      # * +options+   - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -303,54 +304,54 @@ module Azure
       #
       # ==== Attributes
       #
-      # * +name+              - String. The name of the container to list blobs for. 
-      # * +options+           - Hash. Optional parameters. 
+      # * +name+              - String. The name of the container to list blobs for.
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:prefix+           - String. Filters the results to return only blobs 
+      # * +:prefix+           - String. Filters the results to return only blobs
       #   whose name begins with the specified prefix. (optional)
-      # * +:delimiter+        - String. When the request includes this parameter, the operation 
-      #   returns a BlobPrefix element in the response body that acts as a 
-      #   placeholder for all blobs whose names begin with the same substring 
-      #   up to the appearance of the delimiter character. The delimiter may 
+      # * +:delimiter+        - String. When the request includes this parameter, the operation
+      #   returns a BlobPrefix element in the response body that acts as a
+      #   placeholder for all blobs whose names begin with the same substring
+      #   up to the appearance of the delimiter character. The delimiter may
       #   be a single character or a string.
-      # * +:marker+           - String. An identifier that specifies the portion of the 
+      # * +:marker+           - String. An identifier that specifies the portion of the
       #   list to be returned. This value comes from the property
-      #   Azure::Service::EnumerationResults.continuation_token when 
-      #   there are more blobs available than were returned. The 
+      #   Azure::Service::EnumerationResults.continuation_token when
+      #   there are more blobs available than were returned. The
       #   marker value may then be used here to request the next set
       #   of list items. (optional)
-      # * +:max_results+      - Integer. Specifies the maximum number of blobs to return. 
-      #   If max_results is not specified, or is a value greater than 
-      #   5,000, the server will return up to 5,000 items. If it is set 
-      #   to a value less than or equal to zero, the server will return 
+      # * +:max_results+      - Integer. Specifies the maximum number of blobs to return.
+      #   If max_results is not specified, or is a value greater than
+      #   5,000, the server will return up to 5,000 items. If it is set
+      #   to a value less than or equal to zero, the server will return
       #   status code 400 (Bad Request). (optional)
       # * +:metadata+         - Boolean. Specifies whether or not to return the blob metadata.
       #   (optional, Default=false)
-      # * +:snapshots+        - Boolean. Specifies that snapshots should be included in the 
-      #   enumeration. Snapshots are listed from oldest to newest in the 
+      # * +:snapshots+        - Boolean. Specifies that snapshots should be included in the
+      #   enumeration. Snapshots are listed from oldest to newest in the
       #   response. (optional, Default=false)
-      # * +:uncomittedblobs+  - Boolean. Specifies that blobs for which blocks have been uploaded, 
+      # * +:uncomittedblobs+  - Boolean. Specifies that blobs for which blocks have been uploaded,
       #   but which have not been committed using put_block_list, be included
       #   in the response. (optional, Default=false)
-      # * +:copy+             - Boolean. Specifies that metadata related to any current or previous 
-      #   copy_blob operation should be included in the response. 
+      # * +:copy+             - Boolean. Specifies that metadata related to any current or previous
+      #   copy_blob operation should be included in the response.
       #   (optional, Default=false)
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # NOTE: Metadata requested with the :metadata parameter must have been stored in
-      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob 
-      # service. Beginning with that version, all metadata names must adhere to the naming 
+      # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob
+      # service. Beginning with that version, all metadata names must adhere to the naming
       # conventions for C# identifiers.
       #
       # See: http://msdn.microsoft.com/en-us/library/windowsazure/dd135734.aspx
       #
-      # Any metadata with invalid names which were previously stored, will be returned with the 
+      # Any metadata with invalid names which were previously stored, will be returned with the
       # key "x-ms-invalid-name" in the metadata hash. This may contain multiple values and be an
       # Array (vs a String if it only contains a single value).
-      # 
+      #
       # Returns an Azure::Service::EnumerationResults
       def list_blobs(name, options={})
         query = { "comp" => "list" }
@@ -376,13 +377,13 @@ module Azure
 
       # Public: Creates a new page blob. Note that calling create_page_blob to create a page
       # blob only initializes the blob. To add content to a page blob, call create_blob_pages method.
-      # 
+      #
       # ==== Attributes
       #
       # * +container+ - String. The container name.
       # * +blob+      - String. The blob name.
       # * +length+    - Integer. Specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.
-      # * +options+   - Hash. Optional parameters. 
+      # * +options+   - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -418,7 +419,7 @@ module Azure
         # ensure content-length is 0 and x-ms-blob-content-length is the blob length
         headers["Content-Length"] = 0.to_s
         headers["x-ms-blob-content-length"] = length.to_s
-        
+
         # set x-ms-sequence-number from options (or default to 0)
         headers["x-ms-sequence-number"] = (options[:sequence_number] || 0).to_s
 
@@ -468,7 +469,7 @@ module Azure
       # * +:if_match+               - An ETag value. Specify an ETag value for this conditional header to write the page only if the blob's ETag value matches the value specified. If the values do not match, the Blob service returns status code 412 (Precondition Failed).
       # * +:if_none_match+          - An ETag value. Specify an ETag value for this conditional header to write the page only if the blob's ETag value does not match the value specified. If the values are identical, the Blob service returns status code 412 (Precondition Failed).
       # * +:timeout+                - Integer. A timeout in seconds.
-      # 
+      #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691975.aspx
       #
       # Returns Blob
@@ -511,7 +512,7 @@ module Azure
       # * +blob+         - String. Name of blob.
       # * +start_range+  - Integer. Position of first byte of first page.
       # * +end_range+    - Integer. Position of last byte of of last page.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -543,7 +544,7 @@ module Azure
       end
 
       # Public: Creates a new block blob or updates the content of an existing block blob.
-      # 
+      #
       # Updating an existing block blob overwrites any existing metadata on the blob
       # Partial updates are not supported with create_block_blob the content of the
       # existing blob is overwritten with the content of the new blob. To perform a
@@ -557,7 +558,7 @@ module Azure
       # * +container+   - String. The container name.
       # * +blob+        - String. The blob name.
       # * +content+     - IO or String. The content of the blob.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -583,7 +584,7 @@ module Azure
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = blob_uri(container, blob, query)
-        
+
         headers = { }
 
         # set x-ms-blob-type to BlockBlob
@@ -621,7 +622,7 @@ module Azure
       # * +blob+        - String. The blob name.
       # * +block_id+    - String. The block id. Note: this should be the raw block id, not Base64 encoded.
       # * +content+     - IO or String. The content of the blob.
-      # * +options+      - Hash. Optional parameters. 
+      # * +options+      - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -648,27 +649,27 @@ module Azure
       end
 
       # Public: Commits existing blob blocks to a blob.
-      #  
+      #
       # This method writes a blob by specifying the list of block IDs that make up the
-      # blob. In order to be written as part of a blob, a block must have been 
+      # blob. In order to be written as part of a blob, a block must have been
       # successfully written to the server in a prior create_blob_block method.
-      # 
-      # You can call Put Block List to update a blob by uploading only those blocks 
-      # that have changed, then committing the new and existing blocks together. 
-      # You can do this by specifying whether to commit a block from the committed 
+      #
+      # You can call Put Block List to update a blob by uploading only those blocks
+      # that have changed, then committing the new and existing blocks together.
+      # You can do this by specifying whether to commit a block from the committed
       # block list or from the uncommitted block list, or to commit the most recently
       # uploaded version of the block, whichever list it may belong to.
-      # 
+      #
       # ==== Attributes
       #
       # * +container+   - String. The container name.
       # * +blob+        - String. The blob name.
-      # * +block_list+  - Array. A ordered list of lists in the following format: 
+      # * +block_list+  - Array. A ordered list of lists in the following format:
       #   [ ["block_id1", :committed], ["block_id2", :uncommitted], ["block_id3"], ["block_id4", :committed]... ]
-      #   The first element of the inner list is the block_id, the second is optional 
-      #   and can be either :committed or :uncommitted to indicate in which group of blocks 
+      #   The first element of the inner list is the block_id, the second is optional
+      #   and can be either :committed or :uncommitted to indicate in which group of blocks
       #   the id should be looked for. If it is omitted, the latest of either group will be used.
-      # * +options+     - Hash. Optional parameters. 
+      # * +options+     - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -682,8 +683,8 @@ module Azure
       # * +:metadata+              - Hash. Custom metadata values to store with the blob.
       # * +:timeout+               - Integer. A timeout in seconds.
       #
-      # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx 
-      # 
+      # See http://msdn.microsoft.com/en-us/library/windowsazure/dd179467.aspx
+      #
       # Returns nil on success
       def commit_blob_blocks(container, blob, block_list, options={})
         query = { "comp" => "blocklist" }
@@ -709,12 +710,12 @@ module Azure
       end
 
       # Public: Retrieves the list of blocks that have been uploaded as part of a block blob.
-      # 
+      #
       # There are two block lists maintained for a blob:
-      # 1) Committed Block List: The list of blocks that have been successfully 
+      # 1) Committed Block List: The list of blocks that have been successfully
       #    committed to a given blob with commitBlobBlocks.
-      # 2) Uncommitted Block List: The list of blocks that have been uploaded for a 
-      #    blob using Put Block (REST API), but that have not yet been committed. 
+      # 2) Uncommitted Block List: The list of blocks that have been uploaded for a
+      #    blob using Put Block (REST API), but that have not yet been committed.
       #    These blocks are stored in Windows Azure in association with a blob, but do
       #    not yet form part of the blob.
       #
@@ -722,13 +723,13 @@ module Azure
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:blocklist_type+ - Symbol. One of :all, :committed, :uncommitted. Defaults to :all (optional)
-      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:timeout+        - Integer. A timeout in seconds.
       #
@@ -757,12 +758,12 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from.
       # * +:timeout+       - Integer. A timeout in seconds.
       #
@@ -792,12 +793,12 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+      - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from.
       # * +:timeout+       - Integer. A timeout in seconds.
       #
@@ -821,21 +822,21 @@ module Azure
         result
       end
 
-      # Public: Returns a list of active page ranges for a page blob. Active page ranges are 
+      # Public: Returns a list of active page ranges for a page blob. Active page ranges are
       # those that have been populated with data.
       #
       # ==== Attributes
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:start_range+    - Integer. Position of first byte of first page. (optional)
       # * +:end_range+      - Integer. Position of last byte of of last page. (optional)
-      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:timeout+        - Integer. A timeout in seconds.
       #
@@ -869,7 +870,7 @@ module Azure
       #
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -879,33 +880,33 @@ module Azure
       # * +:content_language+         - String. Content language for the blob. Will be saved with blob.
       # * +:content_md5+              - String. Content MD5 for the blob. Will be saved with blob.
       # * +:cache_control+            - String. Cache control for the blob. Will be saved with blob.
-      # * +:content_length+           - Integer. Resizes a page blob to the specified size. If the specified 
-      #   value is less than the current size of the blob, then all pages above 
-      #   the specified value are cleared. This property cannot be used to change 
-      #   the size of a block blob. Setting this property for a block blob returns 
+      # * +:content_length+           - Integer. Resizes a page blob to the specified size. If the specified
+      #   value is less than the current size of the blob, then all pages above
+      #   the specified value are cleared. This property cannot be used to change
+      #   the size of a block blob. Setting this property for a block blob returns
       #   status code 400 (Bad Request).
-      # * +:sequence_number_action+   - Symbol. This property indicates how the service should modify the sequence 
-      #   number for the blob. Required if :sequence_number is used. This property 
+      # * +:sequence_number_action+   - Symbol. This property indicates how the service should modify the sequence
+      #   number for the blob. Required if :sequence_number is used. This property
       #   applies to page blobs only.
       #
       #   Specify one of the following options for this property:
       #
-      #   * +:max+        - Sets the sequence number to be the higher of the value included with 
+      #   * +:max+        - Sets the sequence number to be the higher of the value included with
       #     the request and the value currently stored for the blob.
       #   * +:update+     - Sets the sequence number to the value included with the request.
-      #   * +:increment+  - Increments the value of the sequence number by 1. If specifying this 
+      #   * +:increment+  - Increments the value of the sequence number by 1. If specifying this
       #     option, do not include the sequence_number option; doing so will return
       #     status code 400 (Bad Request).
-      # * +:sequence_number+          - Integer. This property sets the blob's sequence number. The sequence number is a 
-      #   user-controlled property that you can use to track requests and manage concurrency 
-      #   issues. Required if the :sequence_number_action option is set to :max or :update. 
+      # * +:sequence_number+          - Integer. This property sets the blob's sequence number. The sequence number is a
+      #   user-controlled property that you can use to track requests and manage concurrency
+      #   issues. Required if the :sequence_number_action option is set to :max or :update.
       #   This property applies to page blobs only.
       #
-      #   Use this together with the :sequence_number_action to update the blob's sequence 
-      #   number, either to the specified value or to the higher of the values specified with 
+      #   Use this together with the :sequence_number_action to update the blob's sequence
+      #   number, either to the specified value or to the higher of the values specified with
       #   the request or currently stored with the blob.
       #
-      #   This header should not be specified if :sequence_number_action is set to :increment; 
+      #   This header should not be specified if :sequence_number_action is set to :increment;
       #   in this case the service automatically increments the sequence number by one.
       #
       #   To set the sequence number to a value of your choosing, this property must be specified
@@ -917,20 +918,20 @@ module Azure
       # The semantics for updating a blob's properties are as follows:
       #
       # * A page blob's sequence number is updated only if the request meets either of the following conditions:
-      # 
+      #
       #     * The :sequence_number_action property is set to :max or :update, and a value for :sequence_number is also set.
       #     * The :sequence_number_action property is set to :increment, indicating that the service should increment
       #       the sequence number by one.
-      # 
+      #
       # * The size of the page blob is modified only if a value for :content_length is specified.
       #
       # * If :sequence_number and/or :content_length are the only properties specified, then the other properties of the blob
       #   will NOT be modified.
-      # 
+      #
       # * If any one or more of the following properties are set, then all of these properties are set together. If a value is
       #   not provided for a given property when at least one of the properties listed below is set, then that property will be
       #   cleared for the blob.
-      # 
+      #
       #     * :cache_control
       #     * :content_type
       #     * :content_md5
@@ -969,7 +970,7 @@ module Azure
       # * +container+      - String. The container name.
       # * +blob+           - String. The blob name.
       # * +metadata+       - Hash. The custom metadata.
-      # * +options+        - Hash. Optional parameters. 
+      # * +options+        - Hash. Optional parameters.
       #
       # ==== Options
       #
@@ -998,14 +999,14 @@ module Azure
       #
       # * +container+        - String. The container name.
       # * +blob+             - String. The blob name.
-      # * +options+          - Hash. Optional parameters. 
+      # * +options+          - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:start_range+     - Integer. Position of first byte of first page. (optional)
       # * +:end_range+       - Integer. Position of last byte of of last page. (optional)
-      # * +:snapshot+        - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+        - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:get_content_md5+ - Boolean. Return the MD5 hash for the range. This option only valid if
       #   start_range and end_range are specified. (optional)
@@ -1039,18 +1040,18 @@ module Azure
       #
       # * +container+          - String. The container name.
       # * +blob+               - String. The blob name.
-      # * +options+            - Hash. Optional parameters. 
+      # * +options+            - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:snapshot+          - String. An opaque DateTime value that specifies the blob snapshot to 
+      # * +:snapshot+          - String. An opaque DateTime value that specifies the blob snapshot to
       #   retrieve information from. (optional)
       # * +:delete_snapshots+  - Symbol. Used to specify the scope of the delete operation for snapshots.
-      #   This parameter is ignored if a blob does not have snapshots, or if a 
+      #   This parameter is ignored if a blob does not have snapshots, or if a
       #   snapshot is specified in the snapshot parameter. (optional)
-      # 
-      #   Possible values include:  
+      #
+      #   Possible values include:
       #   * +:only+     - Deletes only the snapshots for the blob, but leaves the blob
       #   * +:include+  - Deletes the blob and all of the snapshots for the blob
       # * +:timeout+           - Integer. A timeout in seconds.
@@ -1080,28 +1081,28 @@ module Azure
       #
       # * +container+       - String. The container name.
       # * +blob+            - String. The blob name.
-      # * +options+         - Hash. Optional parameters. 
+      # * +options+         - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:metadata+                 - Hash. Custom metadata values to store with the blob snapshot.
-      # * +:if_modified_since+        - A DateTime value. Specify this option to write the page only if the blob has been 
-      #   modified since the specified date/time. If the blob has not been modified, the 
+      # * +:if_modified_since+        - A DateTime value. Specify this option to write the page only if the blob has been
+      #   modified since the specified date/time. If the blob has not been modified, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:if_unmodified_since+      - A DateTime value. Specify this option to write the page only if the blob has not 
-      #   been modified since the specified date/time. If the blob has been modified, the 
+      # * +:if_unmodified_since+      - A DateTime value. Specify this option to write the page only if the blob has not
+      #   been modified since the specified date/time. If the blob has been modified, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:if_match+                 - An ETag value. Specify an ETag value to write the page only if the blob's ETag 
-      #   value matches the value specified. If the values do not match, the Blob service 
+      # * +:if_match+                 - An ETag value. Specify an ETag value to write the page only if the blob's ETag
+      #   value matches the value specified. If the values do not match, the Blob service
       #   returns status code 412 (Precondition Failed).
-      # * +:if_none_match+            - An ETag value. Specify an ETag value to write the page only if the blob's ETag 
-      #   value does not match the value specified. If the values are identical, the Blob 
+      # * +:if_none_match+            - An ETag value. Specify an ETag value to write the page only if the blob's ETag
+      #   value does not match the value specified. If the values are identical, the Blob
       #   service returns status code 412 (Precondition Failed).
       # * +:timeout+                  - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691971.aspx
-      # 
+      #
       # Returns the snapshot DateTime value
       def create_blob_snapshot(container, blob, options={})
         query = { "comp" => "snapshot" }
@@ -1125,58 +1126,58 @@ module Azure
       end
 
       # Public: Copies a source blob to a destination blob within the same storage account.
-      # 
+      #
       # ==== Attributes
       #
       # * +source_container+      - String. The destination container name to copy to.
       # * +source_blob+           - String. The destination blob name to copy to.
       # * +destination_container+ - String. The source container name to copy from.
       # * +destination_blob+      - String. The source blob name to copy from.
-      # * +options+               - Hash. Optional parameters. 
+      # * +options+               - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       # * +:source_snapshot+            - String. A snapshot id for the source blob
-      # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not 
-      #   specified, the operation will copy the source blob metadata to the destination 
-      #   blob. If this parameter is specified, the destination blob is created with the 
+      # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not
+      #   specified, the operation will copy the source blob metadata to the destination
+      #   blob. If this parameter is specified, the destination blob is created with the
       #   specified metadata, and metadata is not copied from the source blob.
-      # * +:source_if_modified_since+   - A DateTime value. Specify this option to write the page only if the source blob 
-      #   has been modified since the specified date/time. If the blob has not been 
+      # * +:source_if_modified_since+   - A DateTime value. Specify this option to write the page only if the source blob
+      #   has been modified since the specified date/time. If the blob has not been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
       # * +:source_if_unmodified_since+ - A DateTime value. Specify this option to write the page only if the source blob
-      #   has not been modified since the specified date/time. If the blob has been 
+      #   has not been modified since the specified date/time. If the blob has been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:source_if_match+            - An ETag value. Specify an ETag value to write the page only if the source blob's 
-      #   ETag value matches the value specified. If the values do not match, the Blob 
+      # * +:source_if_match+            - An ETag value. Specify an ETag value to write the page only if the source blob's
+      #   ETag value matches the value specified. If the values do not match, the Blob
       #   service returns status code 412 (Precondition Failed).
-      # * +:source_if_none_match+       - An ETag value. Specify an ETag value to write the page only if the source blob's 
-      #   ETag value does not match the value specified. If the values are identical, the 
+      # * +:source_if_none_match+       - An ETag value. Specify an ETag value to write the page only if the source blob's
+      #   ETag value does not match the value specified. If the values are identical, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_modified_since+     - A DateTime value. Specify this option to write the page only if the destination 
-      #   blob has been modified since the specified date/time. If the blob has not been 
+      # * +:dest_if_modified_since+     - A DateTime value. Specify this option to write the page only if the destination
+      #   blob has been modified since the specified date/time. If the blob has not been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_unmodified_since+   - A DateTime value. Specify this option to write the page only if the destination 
-      #   blob has not been modified since the specified date/time. If the blob has been 
+      # * +:dest_if_unmodified_since+   - A DateTime value. Specify this option to write the page only if the destination
+      #   blob has not been modified since the specified date/time. If the blob has been
       #   modified, the Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_match+              - An ETag value. Specify an ETag value to write the page only if the destination 
-      #   blob's ETag value matches the value specified. If the values do not match, the 
+      # * +:dest_if_match+              - An ETag value. Specify an ETag value to write the page only if the destination
+      #   blob's ETag value matches the value specified. If the values do not match, the
       #   Blob service returns status code 412 (Precondition Failed).
-      # * +:dest_if_none_match+         - An ETag value. Specify an ETag value to write the page only if the destination 
-      #   blob's ETag value does not match the value specified. If the values are 
+      # * +:dest_if_none_match+         - An ETag value. Specify an ETag value to write the page only if the destination
+      #   blob's ETag value does not match the value specified. If the values are
       #   identical, the Blob service returns status code 412 (Precondition Failed).
       # * +:timeout+                    - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/dd894037.aspx
       #
-      # Returns a tuple of (copy_id, copy_status). 
+      # Returns a tuple of (copy_id, copy_status).
       #
-      # * +copy_id+     - String identifier for this copy operation. Use with get_blob or get_blob_properties to check 
+      # * +copy_id+     - String identifier for this copy operation. Use with get_blob or get_blob_properties to check
       #   the status of this copy operation, or pass to abort_copy_blob to abort a pending copy.
       # * +copy_status+ - String. The state of the copy operation, with these values:
       #   "success" - The copy completed successfully.
-      #   "pending" - The copy is in progress. 
+      #   "pending" - The copy is in progress.
       #
       def copy_blob(destination_container, destination_blob, source_container, source_blob, options={})
         query = { }
@@ -1209,13 +1210,13 @@ module Azure
       # ==== Attributes
       #
       # * +container+          - String. The container name.
-      # * +blob+               - String. The blob name.     
-      # * +options+            - Hash. Optional parameters. 
+      # * +blob+               - String. The blob name.
+      # * +options+            - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
-      # * +:duration+          - Integer. Default -1. Specifies the duration of the lease, in seconds, or negative one (-1) 
+      # Accepted key/value pairs in options parameter are:
+      # * +:duration+          - Integer. Default -1. Specifies the duration of the lease, in seconds, or negative one (-1)
       #   for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. (optional)
       # * +:proposed_lease_id+ - String. Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request)
       #   if the proposed lease ID is not in the correct format. (optional)
@@ -1223,7 +1224,7 @@ module Azure
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
       #
-      # Returns a String of the new unique lease id. While the lease is active, you must include the lease ID with any request 
+      # Returns a String of the new unique lease id. While the lease is active, you must include the lease ID with any request
       # to write to the blob, or to renew, change, or release the lease. A successful renew operation also returns the lease id
       # for the active lease.
       #
@@ -1245,9 +1246,9 @@ module Azure
         response.headers["x-ms-lease-id"]
       end
 
-      # Public: Renews the lease. The lease can be renewed if the lease ID specified on the request matches that 
-      # associated with the blob. Note that the lease may be renewed even if it has expired as long as the blob 
-      # has not been modified or leased again since the expiration of that lease. When you renew a lease, the 
+      # Public: Renews the lease. The lease can be renewed if the lease ID specified on the request matches that
+      # associated with the blob. Note that the lease may be renewed even if it has expired as long as the blob
+      # has not been modified or leased again since the expiration of that lease. When you renew a lease, the
       # lease duration clock resets.
       #
       # ==== Attributes
@@ -1255,11 +1256,11 @@ module Azure
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
       # * +lease+             - String. The lease id
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
+      # Accepted key/value pairs in options parameter are:
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
@@ -1279,8 +1280,8 @@ module Azure
         response.headers["x-ms-lease-id"]
       end
 
-      # Public: Releases the lease. The lease may be released if the lease ID specified on the request matches that 
-      # associated with the blob. Releasing the lease allows another client to immediately acquire the lease for 
+      # Public: Releases the lease. The lease may be released if the lease ID specified on the request matches that
+      # associated with the blob. Releasing the lease allows another client to immediately acquire the lease for
       # the blob as soon as the release is complete.
       #
       # ==== Attributes
@@ -1288,11 +1289,11 @@ module Azure
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
       # * +lease+             - String. The lease id.
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
+      # Accepted key/value pairs in options parameter are:
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
@@ -1312,38 +1313,38 @@ module Azure
         nil
       end
 
-      # Public: Breaks the lease, if the blob has an active lease. Once a lease is broken, it cannot be renewed. Any 
-      # authorized request can break the lease; the request is not required to specify a matching lease ID. When a 
-      # lease is broken, the lease break period is allowed to elapse, during which time no lease operation except 
-      # break and release can be performed on the blob. When a lease is successfully broken, the response indicates 
+      # Public: Breaks the lease, if the blob has an active lease. Once a lease is broken, it cannot be renewed. Any
+      # authorized request can break the lease; the request is not required to specify a matching lease ID. When a
+      # lease is broken, the lease break period is allowed to elapse, during which time no lease operation except
+      # break and release can be performed on the blob. When a lease is successfully broken, the response indicates
       # the interval in seconds until a new lease can be acquired.
       #
-      # A lease that has been broken can also be released, in which case another client may immediately acquire the 
+      # A lease that has been broken can also be released, in which case another client may immediately acquire the
       # lease on the blob.
       #
       # ==== Attributes
       #
       # * +container+         - String. The container name.
       # * +blob+              - String. The blob name.
-      # * +options+           - Hash. Optional parameters. 
+      # * +options+           - Hash. Optional parameters.
       #
       # ==== Options
       #
-      # Accepted key/value pairs in options parameter are: 
-      # * +:break_period+     - Integer. The proposed duration of seconds that the lease should continue before it is 
-      #   broken, between 0 and 60 seconds. This break period is only used if it is shorter than 
-      #   the time remaining on the lease. If longer, the time remaining on the lease is used. A 
-      #   new lease will not be available before the break period has expired, but the lease may 
+      # Accepted key/value pairs in options parameter are:
+      # * +:break_period+     - Integer. The proposed duration of seconds that the lease should continue before it is
+      #   broken, between 0 and 60 seconds. This break period is only used if it is shorter than
+      #   the time remaining on the lease. If longer, the time remaining on the lease is used. A
+      #   new lease will not be available before the break period has expired, but the lease may
       #   be held for longer than the break period.
       #
-      #   If this option is not used, a fixed-duration lease breaks after the remaining lease 
+      #   If this option is not used, a fixed-duration lease breaks after the remaining lease
       #   period elapses, and an infinite lease breaks immediately.
       # * +:timeout+          - Integer. A timeout in seconds.
       #
       # See http://msdn.microsoft.com/en-us/library/windowsazure/ee691972.aspx
       #
-      # Returns an Integer of the remaining lease time. This value is the approximate time remaining in the lease 
-      # period, in seconds. This header is returned only for a successful request to break the lease. If the break 
+      # Returns an Integer of the remaining lease time. This value is the approximate time remaining in the lease
+      # period, in seconds. This header is returned only for a successful request to break the lease. If the break
       # is immediate, 0 is returned.
       def break_lease(container, blob, options={})
         query = { "comp" => "lease" }

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -48,11 +48,11 @@ module Azure
       #
       # Returns None
       def create_cloud_service(name, options = {})
-        Azure::Loggerx.error_with_exit "Cloud service name is not valid " unless name
+        Loggerx.error_with_exit "Cloud service name is not valid " unless name
         if get_cloud_service(name)
-          Azure::Loggerx.warn "Cloud service #{name} already exists. Skipped..."
+          Loggerx.warn "Cloud service #{name} already exists. Skipped..."
         else
-          Azure::Loggerx.info "Creating cloud service #{name}."
+          Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -101,7 +101,7 @@ module Azure
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Azure::Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
+        Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
 
@@ -117,7 +117,7 @@ module Azure
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Azure::Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
+        Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
 
@@ -125,7 +125,7 @@ module Azure
         data = export_der(ssh[:cert], ssh[:key])
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
         body = BaseManagement::Serialization.add_certificate_to_xml(data)
-        Azure::Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
+        Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
         request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -16,7 +16,7 @@ require 'azure/cloud_service_management/serialization'
 
 module Azure
   module CloudServiceManagement
-    class CloudServiceManagementService < BaseManagementService
+    class CloudServiceManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -55,7 +55,7 @@ module Azure
           Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
-          request = ManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
           request.call
         end
       end
@@ -65,7 +65,7 @@ module Azure
       # Returns an array of Azure::CloudServiceManagement::CloudService objects
       def list_cloud_services
         request_path = "/services/hostedservices"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.cloud_services_from_xml(response)
       end
@@ -100,7 +100,7 @@ module Azure
       # Returns:  None
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
@@ -116,7 +116,7 @@ module Azure
       # Returns NONE
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
@@ -126,7 +126,7 @@ module Azure
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
         body = Serialization.add_certificate_to_xml(data)
         Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
-        request = ManagementHttpRequest.new(:post, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end
 

--- a/lib/azure/cloud_service_management/cloud_service_management_service.rb
+++ b/lib/azure/cloud_service_management/cloud_service_management_service.rb
@@ -48,11 +48,11 @@ module Azure
       #
       # Returns None
       def create_cloud_service(name, options = {})
-        Loggerx.error_with_exit "Cloud service name is not valid " unless name
+        Azure::Loggerx.error_with_exit "Cloud service name is not valid " unless name
         if get_cloud_service(name)
-          Loggerx.warn "Cloud service #{name} already exists. Skipped..."
+          Azure::Loggerx.warn "Cloud service #{name} already exists. Skipped..."
         else
-          Loggerx.info "Creating cloud service #{name}."
+          Azure::Loggerx.info "Creating cloud service #{name}."
           request_path = "/services/hostedservices"
           body = Serialization.cloud_services_to_xml(name, options)
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -101,7 +101,7 @@ module Azure
       def delete_cloud_service(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
+        Azure::Loggerx.info "Deleting cloud service #{cloud_service_name}. \n"
         request.call
       end
 
@@ -117,15 +117,15 @@ module Azure
       def delete_cloud_service_deployment(cloud_service_name)
         request_path= "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
-        Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
+        Azure::Loggerx.info "Deleting deployment of cloud service \"#{cloud_service_name}\" ..."
         request.call
       end
 
       def upload_certificate(cloud_service_name, ssh)
         data = export_der(ssh[:cert], ssh[:key])
         request_path= "/services/hostedservices/#{cloud_service_name}/certificates"
-        body = Serialization.add_certificate_to_xml(data)
-        Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
+        body = BaseManagement::Serialization.add_certificate_to_xml(data)
+        Azure::Loggerx.info "Uploading certificate to cloud service #{cloud_service_name}..."
         request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
         request.call
       end

--- a/lib/azure/cloud_service_management/serialization.rb
+++ b/lib/azure/cloud_service_management/serialization.rb
@@ -18,6 +18,7 @@ require 'azure/cloud_service_management/cloud_service'
 module Azure
   module CloudServiceManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.cloud_services_to_xml(name, options = {})
         options[:label] = options[:label] || name
 

--- a/lib/azure/core/utility.rb
+++ b/lib/azure/core/utility.rb
@@ -60,7 +60,7 @@ module Azure
         elsif File.exist?(File.join(ENV['HOME'], name))
           File.join(ENV['HOME'], name)
         else
-          Azure::Loggerx.error_with_exit "Unable to find #{name} file  "
+          Loggerx.error_with_exit "Unable to find #{name} file  "
         end
       end
 

--- a/lib/azure/core/utility.rb
+++ b/lib/azure/core/utility.rb
@@ -60,7 +60,7 @@ module Azure
         elsif File.exist?(File.join(ENV['HOME'], name))
           File.join(ENV['HOME'], name)
         else
-          Loggerx.error_with_exit "Unable to find #{name} file  "
+          Azure::Loggerx.error_with_exit "Unable to find #{name} file  "
         end
       end
 

--- a/lib/azure/service/cors.rb
+++ b/lib/azure/service/cors.rb
@@ -1,0 +1,11 @@
+module Azure
+  module Service
+    class Cors 
+      def initialize
+        yield self if block_given?
+      end
+
+      attr_accessor :cors_rules
+    end
+  end
+end

--- a/lib/azure/service/cors_rule.rb
+++ b/lib/azure/service/cors_rule.rb
@@ -1,0 +1,15 @@
+module Azure
+  module Service
+    class CorsRule
+      def initialize
+        yield self if block_given?
+      end
+
+      attr_accessor :allowed_origins
+      attr_accessor :allowed_methods
+      attr_accessor :max_age_in_seconds
+      attr_accessor :exposed_headers
+      attr_accessor :allowed_headers
+    end
+  end
+end

--- a/lib/azure/service/serialization.rb
+++ b/lib/azure/service/serialization.rb
@@ -250,6 +250,7 @@ module Azure
         def service_properties_to_xml(properties)
           builder = Nokogiri::XML::Builder.new(:encoding => 'utf-8') do |xml|
             xml.StorageServiceProperties {
+              xml.DefaultServiceVersion(properties.default_service_version) if properties.default_service_version
               logging_to_xml(properties.logging, xml) if properties.logging
               hour_metrics_to_xml(properties.hour_metrics, xml) if properties.hour_metrics
               minute_metrics_to_xml(properties.minute_metrics, xml) if properties.minute_metrics

--- a/lib/azure/service/storage_service.rb
+++ b/lib/azure/service/storage_service.rb
@@ -35,7 +35,7 @@ module Azure
       # Returns a Hash with the service properties or nil if the operation failed
       def get_service_properties
         uri = service_properties_uri
-        response = call(:get, uri)
+        response = call(:get, uri, nil, service_properties_headers)
         Serialization.service_properties_from_xml response.body
       end
 
@@ -51,7 +51,7 @@ module Azure
         body = Serialization.service_properties_to_xml service_properties
 
         uri = service_properties_uri
-        call(:put, uri, body)
+        call(:put, uri, body, service_properties_headers)
         nil
       end
 
@@ -73,6 +73,10 @@ module Azure
         metadata.each do |key, value|
           headers["x-ms-meta-#{key}"] = value
         end
+      end
+
+      def service_properties_headers
+        {"x-ms-version" => "2013-08-15"}
       end
     end
   end

--- a/lib/azure/service/storage_service_properties.rb
+++ b/lib/azure/service/storage_service_properties.rb
@@ -14,18 +14,23 @@
 #--------------------------------------------------------------------------
 require 'azure/service/logging'
 require 'azure/service/metrics'
+require 'azure/service/cors'
 
 module Azure
   module Service
     class StorageServiceProperties
       def initialize
         @logging = Logging.new
-        @metrics = Metrics.new
+        @hour_metrics = Metrics.new
+        @minute_metrics = Metrics.new
+        @cors = Cors.new
         yield self if block_given?
       end
 
       attr_accessor :logging
-      attr_accessor :metrics
+      attr_accessor :hour_metrics
+      attr_accessor :minute_metrics
+      attr_accessor :cors
       attr_accessor :default_service_version
     end
   end

--- a/lib/azure/service_bus/relay.rb
+++ b/lib/azure/service_bus/relay.rb
@@ -1,0 +1,88 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+require 'azure/service_bus/resource'
+
+module Azure
+  module ServiceBus
+    class Relay < Resource
+      # Public: Initialize the relay endpoint.
+      #
+      # ==== Attributes
+      #
+      # * +name+      - A String with the name of the relay endpoint.
+      # * +options+   - The resource options Hash
+      #
+      # ==== Options
+      #
+      # Accepted key/value pairs in options parameter are:
+      # * +:relay_type+                                  - String. Determines the type of the relay endpoint.
+      # * +:requires_client_authorization+               - Boolean. Determines whether or not clients need to authenticate when making calls.
+      # * +:requires_transport_security+                 - Boolean. Determines whether or not the endpoint uses transport security. 
+      #
+      def initialize(name, options = {})
+        normalized_options = {}
+        normalized_options["RelayType"] = options[:relay_type].to_s if options.has_key?(:relay_type)
+        normalized_options["RequiresClientAuthorization"] = options[:requires_client_authorization].to_s if options.has_key?(:requires_client_authorization)
+        normalized_options["RequiresTransportSecurity"] = options[:requires_transport_security].to_s if options.has_key?(:requires_transport_security)
+        super(name, normalized_options)
+      end
+
+      # RelayType: String
+      #
+      # Displays the relay type of the endpoint.
+      def relay_type
+        description['RelayType']
+      end
+
+      def relay_type=(val)
+        _set 'RelayType', val
+      end
+      
+      # RequiresClientAuthorization: Boolean
+      #
+      # Determines whether or not clients need to authenticate when making calls. 
+      #
+      # Default: true
+      def requires_client_authorization
+        to_bool description['RequiresClientAuthorization']
+      end
+
+      def requires_client_authorization=(val)
+        _set 'RequiresClientAuthorization', val
+      end
+
+      # RequiresTransportSecurity: Boolean
+      #
+      # Determines whether or not the endpoint uses transport security. 
+      #
+      # Default: true
+      def requires_transport_security
+        to_bool description['RequiresTransportSecurity']
+      end
+
+      def requires_transport_security=(val)
+        _set 'RequiresTransportSecurity', val
+      end
+
+      def ordered_props
+        [
+          'RelayType',
+          'RequiresClientAuthorization',
+          'RequiresTransportSecurity'
+        ]
+      end
+    end
+  end
+end

--- a/lib/azure/service_bus/relay.rb
+++ b/lib/azure/service_bus/relay.rb
@@ -27,13 +27,13 @@ module Azure
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:relay_type+                                  - String. Determines the type of the relay endpoint.
+      # * +:relay_type+                                  - String. Determines the type of the relay endpoint. This is required.
       # * +:requires_client_authorization+               - Boolean. Determines whether or not clients need to authenticate when making calls.
       # * +:requires_transport_security+                 - Boolean. Determines whether or not the endpoint uses transport security. 
       #
-      def initialize(name, options = {})
+      def initialize(name, options)
         normalized_options = {}
-        normalized_options["RelayType"] = options[:relay_type].to_s if options.has_key?(:relay_type)
+        normalized_options["RelayType"] = options[:relay_type].to_s
         normalized_options["RequiresClientAuthorization"] = options[:requires_client_authorization].to_s if options.has_key?(:requires_client_authorization)
         normalized_options["RequiresTransportSecurity"] = options[:requires_transport_security].to_s if options.has_key?(:requires_transport_security)
         super(name, normalized_options)

--- a/lib/azure/service_bus/serialization.rb
+++ b/lib/azure/service_bus/serialization.rb
@@ -18,6 +18,7 @@ require "azure/service_bus/queue"
 require "azure/service_bus/topic"
 require "azure/service_bus/subscription"
 require "azure/service_bus/rule"
+require "azure/service_bus/relay"
 
 require "azure/service/enumeration_results"
 

--- a/lib/azure/service_bus/service_bus_service.rb
+++ b/lib/azure/service_bus/service_bus_service.rb
@@ -34,8 +34,66 @@ module Azure
             req.headers.delete "x-ms-version"
             req.headers.delete "DataServiceVersion"
             req.headers.delete "MaxDataServiceVersion"
+
+            req.headers.add "X-Process-At", "servicebus"
             res.call
           end
+      end
+
+      # Creates a new relay endpoint. Once created, this relay endpoint resource manifest is immutable. 
+      # 
+      # ==== Attributes
+      #
+      # * +relay+        - Azure::ServiceBus::Relay instance to create on server, or a string of the relay endpoint name
+      # * +options+      - Hash. The relay endpoint properties. 
+      #
+      # ==== Options
+      #
+      # Accepted key/value pairs in options parameter are:
+      # * +:relay_type+                                  - String. Determines the type of the relay endpoint.
+      # * +:requires_client_authorization+               - Boolean. Determines whether or not clients need to authenticate when making calls.
+      # * +:requires_transport_security+                 - Boolean. Determines whether or not the endpoint uses transport security. 
+      #
+      def create_relay(relay, options={})
+        relay = _new_or_existing(Azure::ServiceBus::Relay, relay, options ? options : {})
+        create_resource_entry(:relay, relay, relay.name)
+      end
+
+      # Deletes an existing relay endpoint. 
+      # 
+      # ==== Attributes
+      #
+      # * +relay+ - Azure::ServiceBus::Relay instance to delete or a string of the relay endpoint name
+      def delete_relay(relay)
+        delete_resource_entry(:relay, _name_for(relay))
+      end
+
+      # Retrieves the description for the specified relay endpoint.
+      # 
+      # ==== Attributes
+      #
+      # * +relay+ - Azure::ServiceBus::Relay instance to retrieve or a string of the relay endpoint name
+      def get_relay(relay)
+        resource_entry(:relay, _name_for(relay))
+      end
+
+      # Enumerates the relay endpoints in the service namespace.
+      #
+      # ==== Attributes
+      #
+      # * +options+    - Hash. Optional parameters.
+      #
+      # ==== Options
+      #
+      # Accepted key/value pairs in options parameter are:
+      # * +:skip+      - Integer. Number of queues to skip.
+      # * +:top+       - Integer. Number of queues to list.
+      def list_relays(options={})
+        query = {}
+        query["$skip"] = options[:skip].to_i.to_s if options[:skip]
+        query["$top"] = options[:top].to_i.to_s if options[:top]
+
+        resource_list(:relay, query)
       end
 
       # Creates a new queue. Once created, this queue's resource manifest is immutable. 
@@ -783,6 +841,12 @@ module Azure
       end
 
       protected
+      def relay_uri(relay, query={})
+        query["api-version"] = "2013-10"
+        generate_uri(relay, query)
+      end
+
+      protected
       def queue_uri(topic, query={})
         generate_uri(topic, query)
       end
@@ -802,6 +866,11 @@ module Azure
       protected
       def subscription_list_uri(topic, query={})
         resource_list_uri(:subscription, query, topic)
+      end
+
+      protected
+      def relay_list_uri(query={})
+        resource_list_uri(:relay, query)
       end
 
       protected

--- a/lib/azure/service_bus/service_bus_service.rb
+++ b/lib/azure/service_bus/service_bus_service.rb
@@ -34,8 +34,7 @@ module Azure
             req.headers.delete "x-ms-version"
             req.headers.delete "DataServiceVersion"
             req.headers.delete "MaxDataServiceVersion"
-
-            req.headers.add "X-Process-At", "servicebus"
+            req.headers["X-Process-At"] = "servicebus"
             res.call
           end
       end

--- a/lib/azure/sql_database_management/serialization.rb
+++ b/lib/azure/sql_database_management/serialization.rb
@@ -17,6 +17,7 @@ require 'azure/sql_database_management/sql_database'
 module Azure
   module SqlDatabaseManagement
     module Serialization
+      extend Azure::Core::Utility
 
       def self.database_to_xml(login, password, location)
         builder = Nokogiri::XML::Builder.new do |xml|

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -16,7 +16,7 @@ require 'azure/sql_database_management/serialization'
 
 module Azure
   module SqlDatabaseManagement
-    class SqlDatabaseManagementService < BaseManagementService
+    class SqlDatabaseManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -30,7 +30,7 @@ module Azure
       # Returns an array of Azure::SqlDatabaseManagement::SqlDatabase objects
       def list_servers
         request_path = '/servers'
-        request = SqlManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::SqlManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.databases_from_xml(response)
       end
@@ -49,7 +49,7 @@ module Azure
       def create_server(login, password, location)
         body = Serialization.database_to_xml(login, password, location)
         request_path = '/servers'
-        request = SqlManagementHttpRequest.new(:post, request_path, body)
+        request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
         Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
@@ -69,7 +69,7 @@ module Azure
       def delete_server(name)
         if get_sql_server(name)
           request_path = "/servers/#{name}"
-          request = SqlManagementHttpRequest.new(:delete, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
           Loggerx.info "Deleted database server #{name}."
         end
@@ -90,7 +90,7 @@ module Azure
         if get_sql_server(name)
           body = Serialization.reset_password_to_xml(password)
           request_path = "/servers/#{name}?op=ResetPassword"
-          request = SqlManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
           Loggerx.info "Password for server #{name} changed successfully."
         end
@@ -127,7 +127,7 @@ module Azure
             request_path = "/servers/#{server_name}/firewallrules/#{rule_name}?op=AutoDetectClientIP"
             method = :post
           end
-          request = SqlManagementHttpRequest.new(method, request_path, body)
+          request = BaseManagement::SqlManagementHttpRequest.new(method, request_path, body)
           request.headers['x-ms-version'] = '1.0'
           request.uri = URI.parse(Azure.config.sql_database_management_endpoint + Azure.config.subscription_id + request_path)
           # Management certificate authentication Endpoint throws errors for this operation. Need to re-visit
@@ -151,7 +151,7 @@ module Azure
       def list_sql_server_firewall_rules(server_name)
         if get_sql_server(server_name)
           request_path = "/servers/#{server_name}/firewallrules"
-          request = SqlManagementHttpRequest.new(:get, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:get, request_path)
           response = request.call
           Serialization.database_firewall_from_xml(response)
         end
@@ -173,7 +173,7 @@ module Azure
           raise error
         elsif get_sql_server(server_name)
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
-          request = SqlManagementHttpRequest.new(:delete, request_path)
+          request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
           Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -52,7 +52,7 @@ module Azure
         request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
-        Azure::Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
+        Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
         sql_server
       end
 
@@ -71,7 +71,7 @@ module Azure
           request_path = "/servers/#{name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted database server #{name}."
+          Loggerx.info "Deleted database server #{name}."
         end
       end
 
@@ -92,7 +92,7 @@ module Azure
           request_path = "/servers/#{name}?op=ResetPassword"
           request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Azure::Loggerx.info "Password for server #{name} changed successfully."
+          Loggerx.info "Password for server #{name} changed successfully."
         end
       end
 
@@ -134,7 +134,7 @@ module Azure
           # this once the Azure API is working.
 
           request.call
-          Azure::Loggerx.info "Added server-level firewall rule #{rule_name}."
+          Loggerx.info "Added server-level firewall rule #{rule_name}."
         end
       end
 
@@ -175,7 +175,7 @@ module Azure
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Azure::Loggerx.info "Deleted server-level firewall rule #{rule_name}."
+          Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end
       end
 

--- a/lib/azure/sql_database_management/sql_database_management_service.rb
+++ b/lib/azure/sql_database_management/sql_database_management_service.rb
@@ -52,7 +52,7 @@ module Azure
         request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
         response = request.call
         sql_server = Serialization.server_name_from_xml(response, login, location)
-        Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
+        Azure::Loggerx.info "SQL database server #{sql_server.name} is created." if sql_server
         sql_server
       end
 
@@ -71,7 +71,7 @@ module Azure
           request_path = "/servers/#{name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted database server #{name}."
+          Azure::Loggerx.info "Deleted database server #{name}."
         end
       end
 
@@ -92,7 +92,7 @@ module Azure
           request_path = "/servers/#{name}?op=ResetPassword"
           request = BaseManagement::SqlManagementHttpRequest.new(:post, request_path, body)
           request.call
-          Loggerx.info "Password for server #{name} changed successfully."
+          Azure::Loggerx.info "Password for server #{name} changed successfully."
         end
       end
 
@@ -134,7 +134,7 @@ module Azure
           # this once the Azure API is working.
 
           request.call
-          Loggerx.info "Added server-level firewall rule #{rule_name}."
+          Azure::Loggerx.info "Added server-level firewall rule #{rule_name}."
         end
       end
 
@@ -175,7 +175,7 @@ module Azure
           request_path = "/servers/#{server_name}/firewallrules/#{rule_name}"
           request = BaseManagement::SqlManagementHttpRequest.new(:delete, request_path)
           request.call
-          Loggerx.info "Deleted server-level firewall rule #{rule_name}."
+          Azure::Loggerx.info "Deleted server-level firewall rule #{rule_name}."
         end
       end
 

--- a/lib/azure/storage_management/serialization.rb
+++ b/lib/azure/storage_management/serialization.rb
@@ -20,6 +20,7 @@ module Azure
     # Storage management serialization module is responsible for converting
     # the objects to XML and vice versa.
     module Serialization
+      extend Azure::Core::Utility
       def self.storage_services_to_xml(name, options = {})
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.CreateStorageServiceInput(

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -99,9 +99,9 @@ module Azure
       def create_storage_account(name, options = {})
         raise 'Name not specified' if !name || name.class != String || name.empty?
         if get_storage_account(name)
-          Azure::Loggerx.warn "Storage Account #{name} already exists. Skipped..."
+          Loggerx.warn "Storage Account #{name} already exists. Skipped..."
         else
-          Azure::Loggerx.info "Creating Storage Account #{name}."
+          Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -135,13 +135,13 @@ module Azure
       # Fails with RuntimeError if invalid options specified
       def update_storage_account(name, options = {})
         if get_storage_account name
-          Azure::Loggerx.info "Account '#{name}' exists, updating..."
+          Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
           request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
-          Azure::Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
+          Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
         end
       end
 
@@ -154,7 +154,7 @@ module Azure
       #
       # Returns:  None
       def delete_storage_account(name)
-        Azure::Loggerx.info "Deleting Storage Account #{name}."
+        Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -17,7 +17,7 @@ require 'azure/storage_management/serialization'
 module Azure
   module StorageManagement
     # Provides Storage Management API
-    class StorageManagementService < BaseManagementService
+    class StorageManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -27,7 +27,7 @@ module Azure
       # Returns an array of Azure::StorageManagement::StorageAccount objects
       def list_storage_accounts
         request_path = '/services/storageservices'
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.storage_services_from_xml(response)
       end
@@ -65,7 +65,7 @@ module Azure
       # Returns the storage account
       def get_storage_account_properties(name)
         request_path = "/services/storageservices/#{name}"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.storage_services_from_xml(response)
       end
@@ -104,7 +104,7 @@ module Azure
           Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
-          request = ManagementHttpRequest.new(:post, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
           request.call
         end
       end
@@ -138,7 +138,7 @@ module Azure
           Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
-          request = ManagementHttpRequest.new(:put, request_path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
           Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
@@ -156,7 +156,7 @@ module Azure
       def delete_storage_account(name)
         Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
-        request = ManagementHttpRequest.new(:delete, request_path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call
       rescue Exception => e
         e.message

--- a/lib/azure/storage_management/storage_management_service.rb
+++ b/lib/azure/storage_management/storage_management_service.rb
@@ -99,9 +99,9 @@ module Azure
       def create_storage_account(name, options = {})
         raise 'Name not specified' if !name || name.class != String || name.empty?
         if get_storage_account(name)
-          Loggerx.warn "Storage Account #{name} already exists. Skipped..."
+          Azure::Loggerx.warn "Storage Account #{name} already exists. Skipped..."
         else
-          Loggerx.info "Creating Storage Account #{name}."
+          Azure::Loggerx.info "Creating Storage Account #{name}."
           body = Serialization.storage_services_to_xml(name, options)
           request_path = '/services/storageservices'
           request = BaseManagement::ManagementHttpRequest.new(:post, request_path, body)
@@ -135,13 +135,13 @@ module Azure
       # Fails with RuntimeError if invalid options specified
       def update_storage_account(name, options = {})
         if get_storage_account name
-          Loggerx.info "Account '#{name}' exists, updating..."
+          Azure::Loggerx.info "Account '#{name}' exists, updating..."
           body = Serialization.storage_update_to_xml options
           request_path = "/services/storageservices/#{name}"
           request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
           request.call
         else
-          Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
+          Azure::Loggerx.warn "Storage Account '#{name}' does not exist. Skipped..."
         end
       end
 
@@ -154,7 +154,7 @@ module Azure
       #
       # Returns:  None
       def delete_storage_account(name)
-        Loggerx.info "Deleting Storage Account #{name}."
+        Azure::Loggerx.info "Deleting Storage Account #{name}."
         request_path = "/services/storageservices/#{name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, request_path)
         request.call

--- a/lib/azure/version.rb
+++ b/lib/azure/version.rb
@@ -17,7 +17,7 @@ module Azure
   class Version
     MAJOR = 0 unless defined? MAJOR
     MINOR = 6 unless defined? MINOR
-    UPDATE = 4 unless defined? UPDATE
+    UPDATE = 5 unless defined? UPDATE
     PRE = nil unless defined? PRE
 
     class << self

--- a/lib/azure/virtual_machine_image_management/serialization.rb
+++ b/lib/azure/virtual_machine_image_management/serialization.rb
@@ -18,7 +18,8 @@ require 'azure/virtual_machine_image_management/virtual_machine_disk'
 module Azure
   module VirtualMachineImageManagement
     module Serialization
-
+      extend Azure::Core::Utility
+      
       def self.virtual_machine_images_from_xml(imageXML)
         os_images = Array.new
         virtual_machine_images = imageXML.css('Images OSImage')

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -59,7 +59,7 @@ module Azure
       #
       # Returns None
       def delete_virtual_machine_disk(disk_name)
-        Azure::Loggerx.info "Deleting Disk \"#{disk_name}\". "
+        Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -16,7 +16,7 @@ require "azure/virtual_machine_image_management/serialization"
 
 module Azure
   module VirtualMachineImageManagement
-    class VirtualMachineImageManagementService < BaseManagementService
+    class VirtualMachineImageManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -27,14 +27,14 @@ module Azure
       # Returns an array of Azure::VirtualMachineImageManagementService objects
       def list_virtual_machine_images
         request_path = "/services/images"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.virtual_machine_images_from_xml(response)
       end
  
     end
 
-    class VirtualMachineDiskManagementService < BaseManagementService
+    class VirtualMachineDiskManagementService < BaseManagement::BaseManagementService
 
       def initialize
         super()
@@ -45,7 +45,7 @@ module Azure
       # Returns an array of Azure::VirtualMachineDiskManagementService objects
       def list_virtual_machine_disks
         request_path = "/services/disks"
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.disks_from_xml(response)
       end
@@ -61,7 +61,7 @@ module Azure
       def delete_virtual_machine_disk(disk_name)
         Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
-        request = ManagementHttpRequest.new(:delete, path)
+        request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call
       end
 

--- a/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
+++ b/lib/azure/virtual_machine_image_management/virtual_machine_image_management_service.rb
@@ -59,7 +59,7 @@ module Azure
       #
       # Returns None
       def delete_virtual_machine_disk(disk_name)
-        Loggerx.info "Deleting Disk \"#{disk_name}\". "
+        Azure::Loggerx.info "Deleting Disk \"#{disk_name}\". "
         path = "/services/disks/#{disk_name}"
         request = BaseManagement::ManagementHttpRequest.new(:delete, path)
         request.call

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -107,7 +107,7 @@ module Azure
             xml.AvailabilitySetName options[:availability_set_name]
             xml.Label Base64.encode64(params[:vm_name]).strip
             xml.OSVirtualHardDisk do
-              xml.MediaLink 'http://' + options[:storage_account_name] + '.blob.core.windows.net/vhds/' + (Time.now.strftime('disk_%Y_%m_%d_%H_%M')) + '.vhd'
+              xml.MediaLink 'http://' + options[:storage_account_name] + '.blob.core.windows.net/vhds/' + (Time.now.strftime('disk_%Y_%m_%d_%H_%M_%S_%L')) + '.vhd'
               xml.SourceImageName params[:image]
             end
             xml.RoleSize options[:vm_size]

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -69,6 +69,9 @@ module Azure
             if options[:virtual_network_name]
               xml.VirtualNetworkName options[:virtual_network_name]
             end
+            if options[:reserved_ip_name]
+              xml.ReservedIPName options[:reserved_ip_name]
+            end
           end
         end
         builder.doc.at_css('Role') << role_to_xml(params, options).at_css('PersistentVMRole').children.to_s

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -18,6 +18,7 @@ require 'base64'
 module Azure
   module VirtualMachineManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.shutdown_virtual_machine_to_xml
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.ShutdownRoleOperation(

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -346,7 +346,7 @@ module Azure
 
       def self.add_data_disk_to_xml(lun, media_link, options)
         if options[:import] && options[:disk_name].nil?
-          Loggerx.error_with_exit "The data disk name is not valid."
+          Azure::Loggerx.error_with_exit "The data disk name is not valid."
         end
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.DataVirtualHardDisk(

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -104,6 +104,7 @@ module Azure
                   xml.SubnetNames do
                     xml.SubnetName options[:subnet_name]
                   end
+                  xml.StaticVirtualNetworkIPAddress options[:static_virtual_network_ipaddress] if options[:static_virtual_network_ipaddress]
                 end
               end
             end

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -147,6 +147,7 @@ module Azure
                 end
               end
             end
+            xml.CustomData params[:custom_data] if params[:custom_data]
           end
         elsif options[:os_type] == 'Windows'
           xml.ConfigurationSet('i:type' => 'WindowsProvisioningConfigurationSet') do

--- a/lib/azure/virtual_machine_management/serialization.rb
+++ b/lib/azure/virtual_machine_management/serialization.rb
@@ -347,7 +347,7 @@ module Azure
 
       def self.add_data_disk_to_xml(lun, media_link, options)
         if options[:import] && options[:disk_name].nil?
-          Azure::Loggerx.error_with_exit "The data disk name is not valid."
+          Loggerx.error_with_exit "The data disk name is not valid."
         end
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.DataVirtualHardDisk(

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -521,9 +521,15 @@ module Azure
       end
 
       def validate_role_size(vm_size)
-        valid_role_sizes = %w(ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4)
+        valid_role_sizes = %w(
+          Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4
+          ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 A8 A9
+          Standard_D1 Standard_D2 Standard_D3 Standard_D4 Standard_D11 Standard_D12 Standard_D13 Standard_D14
+          Standard_DS1 Standard_DS2 Standard_DS3 Standard_DS4 Standard_DS11 Standard_DS12 Standard_DS13 Standard_DS14
+          Standard_G1 Standard_G2 Standard_G3 Standard_G4 Standard_G5
+        )
         if vm_size && !valid_role_sizes.include?(vm_size)
-          Loggerx.error_with_exit "Value '#{vm_size}' specified for parameter 'vm_size' is invalid. Allowed values are 'ExtraSmall,Small,Medium,Large,ExtraLarge,A6,A7'"
+          Loggerx.error_with_exit "Value '#{vm_size}' specified for parameter 'vm_size' is invalid. Allowed values are '#{valid_role_sizes.join(',')}'"
         end
       end
 

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -99,7 +99,7 @@ module Azure
         options[:os_type] = get_os_type(params[:image])
         validate_deployment_params(params, options)
         options[:deployment_name] ||= options[:cloud_service_name]
-        Loggerx.info 'Creating deploymnent...'
+        Loggerx.info 'Creating deployment...'
         options[:cloud_service_name] ||= generate_cloud_service_name(params[:vm_name])
         options[:storage_account_name] ||= generate_storage_account_name(params[:vm_name])
         optionals = {}

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -61,7 +61,6 @@ module Azure
       #
       # * +params+    - Hash.  parameters.
       # * +options+   - Hash.  Optional parameters.
-      # * +add_role+  - true/false. Optional Parameter. Default is false
       #
       #  ==== Params
       #
@@ -90,13 +89,6 @@ module Azure
       # * +:vm_size+                  - String. Specifies the size of the virtual machine instance.
       # * +:winrm_transport+          - Array. Specifies WINRM transport protocol.
       # * +:availability_set_name+    - String. Specifies the availability set name.
-      #
-      #  ==== add_role
-      #
-      # Accepted values are:
-      # * +false+   - Will add a new deployment in a cloud service.
-      # * +true+    - Will add a new role to a cloud service. Atleast one
-      # deployment should exist before you can add a role.
       #
       # Returns Azure::VirtualMachineManagement::VirtualMachine objects of newly created instance.
       #

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -17,7 +17,7 @@ include Azure::VirtualMachineImageManagement
 
 module Azure
   module VirtualMachineManagement
-    class VirtualMachineManagementService < BaseManagementService
+    class VirtualMachineManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -34,7 +34,7 @@ module Azure
         end
         cloud_service_names.each do |cloud_service_name|
           request_path = "/services/hostedservices/#{cloud_service_name}/deploymentslots/production"
-          request = ManagementHttpRequest.new(:get, request_path)
+          request = BaseManagement::ManagementHttpRequest.new(:get, request_path)
           request.warn = true
           response = request.call
           roles << Serialization.virtual_machines_from_xml(response, cloud_service_name)
@@ -139,7 +139,7 @@ module Azure
         Loggerx.error 'Cloud service name is required for adding role.' unless options[:cloud_service_name]
         Loggerx.error 'Storage account name is required for adding role.' unless options[:storage_account_name]
         Loggerx.info 'Deployment in progress...'
-        request = ManagementHttpRequest.new(:post, path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
         request.call
         get_virtual_machine(params[:vm_name], options[:cloud_service_name])
       rescue Exception => e
@@ -207,7 +207,7 @@ module Azure
             path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
             body = Serialization.shutdown_virtual_machine_to_xml
             Loggerx.info "Shutting down virtual machine \"#{vm.vm_name}\" ..."
-            request = ManagementHttpRequest.new(:post, path, body)
+            request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
             request.call
           else
             Loggerx.error 'Cannot perform the shutdown operation on a stopped deployment.'
@@ -236,7 +236,7 @@ module Azure
             path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
             body = Serialization.start_virtual_machine_to_xml
             Loggerx.info "Starting virtual machine \"#{vm.vm_name}\" ..."
-            request = ManagementHttpRequest.new(:post, path, body)
+            request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
             request.call
           end
         else
@@ -260,7 +260,7 @@ module Azure
           path = "/services/hostedservices/#{vm.cloud_service_name}/deployments/#{vm.deployment_name}/roleinstances/#{vm.vm_name}/Operations"
           body = Serialization.restart_virtual_machine_to_xml
           Loggerx.info "Restarting virtual machine \"#{vm.vm_name}\" ..."
-          request = ManagementHttpRequest.new(:post, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
           request.call
         else
           Loggerx.error "Cannot find virtual machine \"#{vm_name}\" under cloud service \"#{cloud_service_name}\"."
@@ -321,7 +321,7 @@ module Azure
           end
           endpoints += input_endpoints
           body = Serialization.update_role_to_xml(endpoints, vm)
-          request = ManagementHttpRequest.new(:put, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, path, body)
           Loggerx.info "Updating endpoints of virtual machine #{vm.vm_name} ..."
           request.call
         else
@@ -347,7 +347,7 @@ module Azure
           endpoints = vm.tcp_endpoints + vm.udp_endpoints
           endpoints.delete_if { |ep| endpoint_name.downcase == ep[:name].downcase }
           body = Serialization.update_role_to_xml(endpoints, vm)
-          request = ManagementHttpRequest.new(:put, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:put, path, body)
           Loggerx.info "Deleting virtual machine endpoint #{endpoint_name} ..."
           request.call
         else
@@ -387,7 +387,7 @@ module Azure
           path = "/services/hostedservices/#{cloud_service_name}/deployments/#{vm.deployment_name}/roles/#{vm_name}/DataDisks"
           body = Serialization.add_data_disk_to_xml(lun, vm.media_link, options)
           Loggerx.info "Adding data disk to virtual machine #{vm_name} ..."
-          request = ManagementHttpRequest.new(:post, path, body)
+          request = BaseManagement::ManagementHttpRequest.new(:post, path, body)
           request.call
         else
           Loggerx.error "Cannot find virtual machine \"#{vm_name}\" under cloud service \"#{cloud_service_name}\"."

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -89,6 +89,7 @@ module Azure
       # * +:vm_size+                  - String. Specifies the size of the virtual machine instance.
       # * +:winrm_transport+          - Array. Specifies WINRM transport protocol.
       # * +:availability_set_name+    - String. Specifies the availability set name.
+      # * +:reserved_ip_name+         - String. Specifies the reserved IP name.
       #
       # Returns Azure::VirtualMachineManagement::VirtualMachine objects of newly created instance.
       #
@@ -99,7 +100,7 @@ module Azure
         options[:os_type] = get_os_type(params[:image])
         validate_deployment_params(params, options)
         options[:deployment_name] ||= options[:cloud_service_name]
-        Loggerx.info 'Creating deploymnent...'
+        Loggerx.info 'Creating deployment...'
         options[:cloud_service_name] ||= generate_cloud_service_name(params[:vm_name])
         options[:storage_account_name] ||= generate_storage_account_name(params[:vm_name])
         optionals = {}

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -18,6 +18,8 @@ include Azure::VirtualMachineImageManagement
 module Azure
   module VirtualMachineManagement
     class VirtualMachineManagementService < BaseManagement::BaseManagementService
+      include  Azure::Core::Utility
+
       def initialize
         super()
       end

--- a/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
+++ b/lib/azure/virtual_machine_management/virtual_machine_management_service.rb
@@ -522,15 +522,15 @@ module Azure
       end
 
       def validate_role_size(vm_size)
-        valid_role_sizes = %w(
+        suggested_role_sizes = %w(
           Basic_A0 Basic_A1 Basic_A2 Basic_A3 Basic_A4
-          ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 A8 A9
+          ExtraSmall Small Medium Large ExtraLarge A5 A6 A7 A8 A9 A10 A11
           Standard_D1 Standard_D2 Standard_D3 Standard_D4 Standard_D11 Standard_D12 Standard_D13 Standard_D14
           Standard_DS1 Standard_DS2 Standard_DS3 Standard_DS4 Standard_DS11 Standard_DS12 Standard_DS13 Standard_DS14
           Standard_G1 Standard_G2 Standard_G3 Standard_G4 Standard_G5
         )
-        if vm_size && !valid_role_sizes.include?(vm_size)
-          Loggerx.error_with_exit "Value '#{vm_size}' specified for parameter 'vm_size' is invalid. Allowed values are '#{valid_role_sizes.join(',')}'"
+        if vm_size && !suggested_role_sizes.include?(vm_size)
+          Loggerx.warn "Value '#{vm_size}' specified for parameter 'vm_size' is not in the list of valid VM role sizes. Suggested values are '#{suggested_role_sizes.join(',')}'"
         end
       end
 

--- a/lib/azure/virtual_network_management/serialization.rb
+++ b/lib/azure/virtual_network_management/serialization.rb
@@ -17,6 +17,7 @@ require 'azure/virtual_network_management/virtual_network'
 module Azure
   module VirtualNetworkManagement
     module Serialization
+      extend Azure::Core::Utility
       def self.virtual_network_from_xml(network_xml)
         virtual_networks = []
         virtual_network_services_xml = network_xml.css(

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -17,7 +17,7 @@ require 'azure/virtual_network_management/serialization'
 module Azure
   module VirtualNetworkManagement
     # VirtualNetworkManagementService
-    class VirtualNetworkManagementService < BaseManagementService
+    class VirtualNetworkManagementService < BaseManagement::BaseManagementService
       def initialize
         super()
       end
@@ -31,7 +31,7 @@ module Azure
       # Azure::VirtualNetworkServiceManagement::VirtualNetwork objects
       def list_virtual_networks
         request_path = '/services/networking/virtualnetwork'
-        request = ManagementHttpRequest.new(:get, request_path, nil)
+        request = BaseManagement::ManagementHttpRequest.new(:get, request_path, nil)
         response = request.call
         Serialization.virtual_network_from_xml(response)
       end
@@ -84,7 +84,7 @@ module Azure
                                                     affinity_group,
                                                     address_space,
                                                     options)
-        request = ManagementHttpRequest.new(:put, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
         Loggerx.info "Creating virtual network #{vnet}."
         request.call
@@ -99,7 +99,7 @@ module Azure
         else
           body = File.read(file)
         end
-        request = ManagementHttpRequest.new(:put, request_path, body)
+        request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
         Loggerx.info 'Creating virtual network.'
         request.call

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -86,7 +86,7 @@ module Azure
                                                     options)
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Azure::Loggerx.info "Creating virtual network #{vnet}."
+        Loggerx.info "Creating virtual network #{vnet}."
         request.call
       end
 
@@ -101,7 +101,7 @@ module Azure
         end
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Azure::Loggerx.info 'Creating virtual network.'
+        Loggerx.info 'Creating virtual network.'
         request.call
       end
     end

--- a/lib/azure/virtual_network_management/virtual_network_management_service.rb
+++ b/lib/azure/virtual_network_management/virtual_network_management_service.rb
@@ -86,7 +86,7 @@ module Azure
                                                     options)
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Loggerx.info "Creating virtual network #{vnet}."
+        Azure::Loggerx.info "Creating virtual network #{vnet}."
         request.call
       end
 
@@ -101,7 +101,7 @@ module Azure
         end
         request = BaseManagement::ManagementHttpRequest.new(:put, request_path, body)
         request.headers['Content-Type'] = 'text/plain'
-        Loggerx.info 'Creating virtual network.'
+        Azure::Loggerx.info 'Creating virtual network.'
         request.call
       end
     end

--- a/test/fixtures/metrics.xml
+++ b/test/fixtures/metrics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<Metrics>
+<HourMetrics>
   <Version>1.0</Version>
   <Enabled>true</Enabled>
   <IncludeAPIs>false</IncludeAPIs>
@@ -7,4 +7,4 @@
     <Enabled>true</Enabled>
     <Days>7</Days>
   </RetentionPolicy>
-</Metrics>
+</HourMetrics>

--- a/test/fixtures/sb_default_create_relay_response.xml
+++ b/test/fixtures/sb_default_create_relay_response.xml
@@ -1,0 +1,15 @@
+<entry xmlns="http://www.w3.org/2005/Atom">
+  <id>https://gmonfort.servicebus.windows.net/gfyhfiwdqger</id>
+  <title type="text">gfyhfiwdqger</title>
+  <published>2012-06-06T05:00:06Z</published>
+  <updated>2012-06-06T05:00:06Z</updated>
+  <author><name>gmonfort</name></author>
+  <link rel="self" href="https://gmonfort.servicebus.windows.net/gfyhfiwdqg"/>
+  <content type="application/xml">
+    <RelayDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+      <RelayType>Http</RelayType>
+      <RequiresClientAuthorization>true</RequiresClientAuthorization>
+      <RequiresTransportSecurity>true</RequiresTransportSecurity>
+    </RelayDescription>
+  </content>
+</entry>

--- a/test/fixtures/storage_service_properties.xml
+++ b/test/fixtures/storage_service_properties.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StorageServiceProperties>
+  <DefaultServiceVersion>2011-08-18</DefaultServiceVersion>
   <Logging>
     <Version>1.0</Version>
     <Delete>true</Delete>

--- a/test/fixtures/storage_service_properties.xml
+++ b/test/fixtures/storage_service_properties.xml
@@ -10,7 +10,7 @@
       <Days>7</Days>
     </RetentionPolicy>
   </Logging>
-  <Metrics>
+  <HourMetrics>
     <Version>1.0</Version>
     <Enabled>true</Enabled>
     <IncludeAPIs>false</IncludeAPIs>
@@ -18,6 +18,37 @@
       <Enabled>true</Enabled>
       <Days>7</Days>
     </RetentionPolicy>
-  </Metrics>
-  <DefaultServiceVersion>2011-08-18</DefaultServiceVersion>
+  </HourMetrics>
+  <MinuteMetrics>
+    <Version>1.0</Version>
+    <Enabled>true</Enabled>
+    <IncludeAPIs>false</IncludeAPIs>
+    <RetentionPolicy>
+      <Enabled>true</Enabled>
+      <Days>7</Days>
+    </RetentionPolicy>
+  </MinuteMetrics>
+  <Cors>
+    <CorsRule>
+      <AllowedOrigins>http://www.contoso.com,http://dummy.uri</AllowedOrigins>
+      <AllowedMethods>PUT,HEAD</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-blob-content-type,x-ms-blob-content-disposition</AllowedHeaders>
+    </CorsRule>
+    <CorsRule>
+      <AllowedOrigins>*</AllowedOrigins>
+      <AllowedMethods>PUT,GET</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-blob-content-type,x-ms-blob-content-disposition</AllowedHeaders>
+    </CorsRule>
+    <CorsRule>
+      <AllowedOrigins>http://www.contoso.com</AllowedOrigins>
+      <AllowedMethods>GET</AllowedMethods>
+      <MaxAgeInSeconds>5</MaxAgeInSeconds>
+      <ExposedHeaders>x-ms-*</ExposedHeaders>
+      <AllowedHeaders>x-ms-client-request-id</AllowedHeaders>
+    </CorsRule>
+  </Cors>
 </StorageServiceProperties>

--- a/test/integration/affinity_group/Affinity_test.rb
+++ b/test/integration/affinity_group/Affinity_test.rb
@@ -24,7 +24,7 @@ describe Azure::BaseManagementService do
     let(:options) { { description: 'Some Description' } }
 
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'get affinity group properties for an existing group' do

--- a/test/integration/affinity_group/Create_Affinity_test.rb
+++ b/test/integration/affinity_group/Create_Affinity_test.rb
@@ -21,7 +21,7 @@ describe Azure::BaseManagementService do
   let(:location) { WindowsImageLocation }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   let(:label) { 'Label Name' }

--- a/test/integration/affinity_group/Delete_Affinity_test.rb
+++ b/test/integration/affinity_group/Delete_Affinity_test.rb
@@ -17,7 +17,7 @@ require 'integration/test_helper'
 describe Azure::BaseManagementService do
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   subject { Azure::BaseManagementService.new }

--- a/test/integration/affinity_group/List_Affinity_test.rb
+++ b/test/integration/affinity_group/List_Affinity_test.rb
@@ -20,7 +20,7 @@ describe Azure::BaseManagementService do
   let(:affinity_group_name) { AffinityGroupNameHelper.name }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     subject.create_affinity_group(affinity_group_name,
                                   WindowsImageLocation,
                                   'Label Name')

--- a/test/integration/affinity_group/Update_Affinity_test.rb
+++ b/test/integration/affinity_group/Update_Affinity_test.rb
@@ -23,7 +23,7 @@ describe Azure::BaseManagementService do
   )
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   subject { Azure::BaseManagementService.new }

--- a/test/integration/database/create_sql_server_firewall_test.rb
+++ b/test/integration/database/create_sql_server_firewall_test.rb
@@ -23,7 +23,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#set_sql_server_firewall_rule" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     after {

--- a/test/integration/database/create_sql_server_test.rb
+++ b/test/integration/database/create_sql_server_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#create_server" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     it "should be able to create a new sql database server." do

--- a/test/integration/database/delete_sql_server_firewall_test.rb
+++ b/test/integration/database/delete_sql_server_firewall_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   subject { Azure::SqlDatabaseManagementService.new }
 
   before {
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     subject.set_sql_server_firewall_rule(sql_server.name, "rule1")
     ip_range = {:start_ip_address => "10.20.30.0", :end_ip_address => "10.20.30.255"}
     subject.set_sql_server_firewall_rule(sql_server.name, "rule2", ip_range)

--- a/test/integration/database/delete_sql_server_test.rb
+++ b/test/integration/database/delete_sql_server_test.rb
@@ -17,7 +17,7 @@ require "integration/test_helper"
 describe Azure::SqlDatabaseManagementService do
 
   before {
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   subject { Azure::SqlDatabaseManagementService.new }

--- a/test/integration/database/list_sql_server_firewall_test.rb
+++ b/test/integration/database/list_sql_server_firewall_test.rb
@@ -22,7 +22,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#list_sql_server_firewall_rules" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       ip_range = {:start_ip_address => "10.20.30.0", :end_ip_address => "10.20.30.255"}
       subject.set_sql_server_firewall_rule(sql_server.name, "rule1", ip_range)
       subject.set_sql_server_firewall_rule(sql_server.name, "rule2")

--- a/test/integration/database/list_sql_servers_test.rb
+++ b/test/integration/database/list_sql_servers_test.rb
@@ -21,7 +21,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#list_servers" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     it "returns a list of SQL databse servers" do

--- a/test/integration/database/reset_password_sql_server_test.rb
+++ b/test/integration/database/reset_password_sql_server_test.rb
@@ -23,7 +23,7 @@ describe Azure::SqlDatabaseManagementService do
   describe "#reset_password" do
 
     before {
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     }
 
     after {

--- a/test/integration/service_bus/relay_test.rb
+++ b/test/integration/service_bus/relay_test.rb
@@ -1,0 +1,144 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+require "integration/test_helper"
+
+describe "ServiceBus Relay" do
+
+  subject { Azure::ServiceBus::ServiceBusService.new }
+  let(:name) { ServiceBusRelayNameHelper.name }
+  let(:name_alternative) { ServiceBusRelayNameHelper.name }
+  let(:description) {{
+    :relay_type => 'Http',
+    :requires_client_authorization => "true",
+    :requires_transport_security => "true"
+  }}
+  let(:description_alternative) {{
+    ::relay_type => 'NetTcp',
+    :requires_client_authorization => "false",
+    :requires_transport_security => "false"
+  }}
+
+  after { ServiceBusRelayNameHelper.clean }
+
+  it "should be able to create a new relay endpoint from a string" do
+    relay = subject.create_relay name
+    relay.must_be_kind_of Azure::ServiceBus::Relay
+    relay.name.must_equal name
+  end
+
+  it "should be able to create a new relay endpoint from a Relay" do
+    relay = subject.create_relay Azure::ServiceBus::Relay.new(name)
+    relay.must_be_kind_of Azure::ServiceBus::Relay
+    relay.name.must_equal name
+  end
+
+  it "should be able to create a new relay endpoint from a string and description Hash" do
+    relay = subject.create_relay name_alternative, description_alternative
+    relay.must_be_kind_of Azure::ServiceBus::Relay
+    relay.name.must_equal name_alternative
+
+    relay.relay_type.must_equal description_alternative[:relay_type]
+    relay.requires_client_authorization.must_equal description_alternative[:requires_client_authorization]
+    relay.requires_transport_security.must_equal description_alternative[:requires_transport_security]
+  end
+
+  it "should be able to create a new relay from a Relay with a description Hash" do
+    relay = subject.create_relay Azure::ServiceBus::Relay.new(name_alternative, description_alternative)
+    relay.must_be_kind_of Azure::ServiceBus::Relay
+    relay.name.must_equal name_alternative
+
+    relay.relay_type.must_equal description_alternative[:relay_type]
+    relay.requires_client_authorization.must_equal description_alternative[:requires_client_authorization]
+    relay.requires_transport_security.must_equal description_alternative[:requires_transport_security]
+  end
+
+  describe 'when a relay exists' do
+    before { subject.create_relay name }
+
+    describe '#delete_relay' do
+      it "should raise exception if the relay endpoint cannot be deleted" do
+        assert_raises(Azure::Core::Http::HTTPError) do
+          subject.delete_relay ServiceBusRelayNameHelper.name
+        end
+      end
+
+      it "should be able to delete the relay endpoint" do
+        response = subject.delete_relay name
+        response.must_equal nil
+      end
+    end
+
+    describe "#get_relay" do
+      it "should be able to get a relay by name" do
+        result = subject.get_relay name
+
+        result.must_be_kind_of Azure::ServiceBus::Relay
+        result.name.must_equal name
+      end
+
+      it "if the relay endpoint doesn't exists it should throw" do
+        assert_raises(Azure::Core::Http::HTTPError) do
+          subject.get_relay ServiceBusRelayNameHelper.name
+        end
+      end
+    end
+
+    describe 'when there are multiple relay endpoints' do
+      let(:name1) { ServiceBusRelayNameHelper.name }
+      let(:name2) { ServiceBusRelayNameHelper.name }
+      before { 
+        subject.create_relay name1
+        subject.create_relay name2
+      }
+      
+      it "should be able to get a list of relays" do
+        result = subject.list_relays
+
+        result.must_be :kind_of?, Array
+        q_found = false
+        q1_found = false
+        q2_found = false
+        result.each { |q|
+          q_found = true if q.name == name
+          q1_found = true if q.name == name1
+          q2_found = true if q.name == name2
+        }
+        assert (q_found and q1_found and q2_found), "list_relays did not return expected relay endpoints"
+      end
+
+      it "should be able to use $skip token with list_relays" do
+        result = subject.list_relays
+        result2 = subject.list_relays({ :skip => 1 })
+        result2.length.must_equal result.length - 1
+        result2[0].id.must_equal result[1].id
+      end
+      
+      it "should be able to use $top token with list_relays" do
+        result = subject.list_relays
+        result.length.wont_equal 1
+
+        result2 = subject.list_relays({ :top => 1 })
+        result2.length.must_equal 1
+      end
+
+      it "should be able to use $skip and $top token together with list_relays" do
+        result = subject.list_relays
+        result2 = subject.list_relays({ :skip => 1, :top => 1 })
+        result2.length.must_equal 1
+        result2[0].id.must_equal result[1].id
+      end
+    end
+  end
+end

--- a/test/integration/service_bus/relay_test.rb
+++ b/test/integration/service_bus/relay_test.rb
@@ -21,28 +21,16 @@ describe "ServiceBus Relay" do
   let(:name_alternative) { ServiceBusRelayNameHelper.name }
   let(:description) {{
     :relay_type => 'Http',
-    :requires_client_authorization => "true",
-    :requires_transport_security => "true"
+    :requires_client_authorization => true,
+    :requires_transport_security => true
   }}
   let(:description_alternative) {{
-    ::relay_type => 'NetTcp',
-    :requires_client_authorization => "false",
-    :requires_transport_security => "false"
+    :relay_type => 'NetTcp',
+    :requires_client_authorization => false,
+    :requires_transport_security => false
   }}
 
   after { ServiceBusRelayNameHelper.clean }
-
-  it "should be able to create a new relay endpoint from a string" do
-    relay = subject.create_relay name
-    relay.must_be_kind_of Azure::ServiceBus::Relay
-    relay.name.must_equal name
-  end
-
-  it "should be able to create a new relay endpoint from a Relay" do
-    relay = subject.create_relay Azure::ServiceBus::Relay.new(name)
-    relay.must_be_kind_of Azure::ServiceBus::Relay
-    relay.name.must_equal name
-  end
 
   it "should be able to create a new relay endpoint from a string and description Hash" do
     relay = subject.create_relay name_alternative, description_alternative
@@ -65,20 +53,7 @@ describe "ServiceBus Relay" do
   end
 
   describe 'when a relay exists' do
-    before { subject.create_relay name }
-
-    describe '#delete_relay' do
-      it "should raise exception if the relay endpoint cannot be deleted" do
-        assert_raises(Azure::Core::Http::HTTPError) do
-          subject.delete_relay ServiceBusRelayNameHelper.name
-        end
-      end
-
-      it "should be able to delete the relay endpoint" do
-        response = subject.delete_relay name
-        response.must_equal nil
-      end
-    end
+    before { subject.create_relay name, description }
 
     describe "#get_relay" do
       it "should be able to get a relay by name" do
@@ -95,12 +70,25 @@ describe "ServiceBus Relay" do
       end
     end
 
+    describe '#delete_relay' do
+      it "should raise exception if the relay endpoint cannot be deleted" do
+        assert_raises(Azure::Core::Http::HTTPError) do
+          subject.delete_relay ServiceBusRelayNameHelper.name
+        end
+      end
+
+      it "should be able to delete the relay endpoint" do
+        response = subject.delete_relay name
+        response.must_equal nil
+      end
+    end
+
     describe 'when there are multiple relay endpoints' do
       let(:name1) { ServiceBusRelayNameHelper.name }
       let(:name2) { ServiceBusRelayNameHelper.name }
       before { 
-        subject.create_relay name1
-        subject.create_relay name2
+        subject.create_relay name1, description
+        subject.create_relay name2, description_alternative
       }
       
       it "should be able to get a list of relays" do

--- a/test/integration/storage_management/storage_management_test.rb
+++ b/test/integration/storage_management/storage_management_test.rb
@@ -38,7 +38,7 @@ describe Azure::StorageManagementService do
   let(:options) { { description: 'sample description' } }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   it 'list storage accounts' do

--- a/test/integration/vm/VM_Create_test.rb
+++ b/test/integration/vm/VM_Create_test.rb
@@ -62,7 +62,7 @@ describe Azure::VirtualMachineManagementService do
   end
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   end
 
   describe '#deployment' do

--- a/test/integration/vm/VM_Delete_test.rb
+++ b/test/integration/vm/VM_Delete_test.rb
@@ -22,7 +22,7 @@ describe Azure::VirtualMachineManagementService do
   let(:csn) { names.last }
   let(:username) { 'admin' }
   before do
-    Loggerx.expects(:puts).at_least_once.returns(nil)
+    Azure::Loggerx.expects(:puts).at_least_once.returns(nil)
     params = {
       vm_name: virtual_machine_name,
       vm_user: 'user',

--- a/test/integration/vm/VM_Operations_test.rb
+++ b/test/integration/vm/VM_Operations_test.rb
@@ -20,7 +20,7 @@ describe Azure::VirtualMachineManagementService do
   subject { Azure::VirtualMachineManagementService.new }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     params = {
       vm_name: vm_name,
       vm_user: 'user',

--- a/test/integration/vnet/Virtual_Network_Create_test.rb
+++ b/test/integration/vnet/Virtual_Network_Create_test.rb
@@ -32,7 +32,7 @@ describe Azure::VirtualNetworkManagement::VirtualNetwork do
   subject { Azure::VirtualNetworkManagementService.new }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
 
     affinity_group_service = Azure::BaseManagementService.new
     affinity_group_service.create_affinity_group(in_affinity_name,

--- a/test/integration/vnet/Virtual_Network_list_test.rb
+++ b/test/integration/vnet/Virtual_Network_list_test.rb
@@ -23,7 +23,7 @@ describe Azure::VirtualNetworkManagement::VirtualNetwork do
   let(:vnet_name) { 'vnet-integration-test' }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     affinity_group_service = Azure::BaseManagementService.new
     affinity_group_service.create_affinity_group(affinity_group_name,
                                                  location,

--- a/test/support/name_generator.rb
+++ b/test/support/name_generator.rb
@@ -57,6 +57,14 @@ QueueNameHelper = NameGenerator.new do |name|
   end
 end
 
+ServiceBusRelayNameHelper = NameGenerator.new do |name|
+  svc = Azure::ServiceBus::ServiceBusService.new
+  begin
+    svc.delete_relay name
+  rescue
+  end
+end
+
 ServiceBusQueueNameHelper = NameGenerator.new do |name|
   svc = Azure::ServiceBus::ServiceBusService.new
   begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@
 #--------------------------------------------------------------------------
 require "minitest/autorun"
 require "mocha/setup"
+require 'timecop'
 
 # Attempt to load turn to show formatted test results
 begin

--- a/test/unit/affinity_group/affinity_group_test.rb
+++ b/test/unit/affinity_group/affinity_group_test.rb
@@ -23,7 +23,7 @@ describe Azure::BaseManagementService do
   let(:response_xml) { nil }
 
   before do
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
   end
 

--- a/test/unit/affinity_group/affinity_group_test.rb
+++ b/test/unit/affinity_group/affinity_group_test.rb
@@ -33,7 +33,7 @@ describe Azure::BaseManagementService do
     let(:method) { :get }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method,
                                              request_path,
                                              nil).returns(mock_request)
     end
@@ -92,7 +92,7 @@ describe Azure::BaseManagementService do
     let(:location_response_body) { Nokogiri::XML location_response.body }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method,
                                              request_path,
                                              anything).returns(mock_request)
       mock_request.expects(:call).returns(
@@ -100,13 +100,13 @@ describe Azure::BaseManagementService do
       ).at_least(0)
       mock_request = mock
 
-      ManagementHttpRequest.stubs(:new).with(:get,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:get,
                                              location_request_path,
                                              nil).returns(mock_request)
       mock_request.expects(:call).returns(location_response_body).at_least(0)
       mock_request = mock
 
-      ManagementHttpRequest.stubs(:new).with(:get,
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:get,
                                              request_path,
                                              nil).returns(mock_request)
       mock_request.expects(:call).returns(
@@ -146,7 +146,7 @@ describe Azure::BaseManagementService do
       Azure::BaseManagementService.any_instance.stubs(
         :affinity_group
       ).returns(true)
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         :get,
         request_path,
         nil

--- a/test/unit/base_management/location_test.rb
+++ b/test/unit/base_management/location_test.rb
@@ -33,7 +33,7 @@ describe Azure::BaseManagement::Location do
     let(:response_body) { Nokogiri::XML response.body }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 

--- a/test/unit/blob/auth/shared_access_signature_test.rb
+++ b/test/unit/blob/auth/shared_access_signature_test.rb
@@ -1,0 +1,71 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+require "test_helper"
+require "azure/blob/auth/shared_access_signature"
+require "base64"
+require "uri"
+
+describe Azure::Blob::Auth::SharedAccessSignature do
+  let(:path) { 'example/path' }
+  let(:options) {
+    {
+      permissions:         'rwd',
+      expiry:              '2013-12-11',
+      resource:            'b',
+      version:             '2013-08-15',
+      content_disposition: 'inline, filename=nyan.cat'
+    }
+  }
+  let(:access_account_name) { 'account-name' }
+  let(:access_key_base64) { Base64.strict_encode64('access-key') }
+
+  subject { Azure::Blob::Auth::SharedAccessSignature.new(path, options, access_account_name, access_key_base64) }
+
+  it "decodes the base64 encoded access_key" do
+    subject.access_key.must_equal 'access-key'
+  end
+
+  describe "#signable_string" do
+
+    it "constructs a string in the required format" do
+      subject.signable_string.must_equal(
+        "rwd\n\n2013-12-11\n/account-name/example/path\n\n2013-08-15\n\ninline, filename=nyan.cat\n\n\n"
+      )
+    end
+  end
+
+  describe "#canonicalized_resource" do
+    it "prefixes and concatenates account name and resource path with forward slashes" do
+      subject.canonicalized_resource.must_equal '/account-name/example/path'
+    end
+  end
+
+  describe "#signed_uri" do
+    let(:uri) { URI(subject.signed_uri) }
+    let(:query_hash) { Hash[URI.decode_www_form(uri.query)] }
+
+    it "maps options to the abbreviated API versions" do
+      query_hash['sp'].must_equal 'rwd'
+      query_hash['se'].must_equal '2013-12-11'
+      query_hash['sr'].must_equal 'b'
+      query_hash['rscd'].must_equal 'inline, filename=nyan.cat'
+    end
+
+    it "includes the signature" do
+      query_hash['sig'].must_equal subject.sign(subject.signable_string)
+    end
+
+  end
+end

--- a/test/unit/cloud_service_management/cloud_service_management_service_test.rb
+++ b/test/unit/cloud_service_management/cloud_service_management_service_test.rb
@@ -34,7 +34,7 @@ describe Azure::CloudServiceManagementService do
 
   describe "#list_cloud_services" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
   
@@ -57,7 +57,7 @@ describe Azure::CloudServiceManagementService do
   
   describe "#get_cloud_service" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
   
@@ -79,14 +79,14 @@ describe Azure::CloudServiceManagementService do
   describe "#create_cloud_service" do
   
     it "Create cloud service return message if cloud service exists of given name." do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       msg = subject.create_cloud_service 'cloud-service-1'
       assert_match(/^Cloud service cloud-service-1 already exists*/, msg)
     end
 
     it "Create cloud service if cloud service doesn't exists of given name." do
       Azure::CloudServiceManagementService.any_instance.stubs(:get_cloud_service).with('cloud-service-3').returns(false)
-      ManagementHttpRequest.any_instance.expects(:call).returns nil
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns nil
       subject.create_cloud_service 'cloud-service-3'
     end
 

--- a/test/unit/cloud_service_management/cloud_service_management_service_test.rb
+++ b/test/unit/cloud_service_management/cloud_service_management_service_test.rb
@@ -29,7 +29,7 @@ describe Azure::CloudServiceManagementService do
   let(:response_body) { Nokogiri::XML response.body }
 
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   describe "#list_cloud_services" do

--- a/test/unit/database/sql_database_server_service_test.rb
+++ b/test/unit/database/sql_database_server_service_test.rb
@@ -24,7 +24,7 @@ describe 'Azure::SqlDatabaseManagementService' do
 
   describe 'SQL Server authentication Endpoint' do
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request.stubs(:headers).returns(response_headers)
       mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
       Azure.config.sql_database_authentication_mode = :sql_server
@@ -156,7 +156,7 @@ describe 'Azure::SqlDatabaseManagementService' do
 
   describe 'Management Certificate authentication Endpoint' do
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request.stubs(:headers).returns(response_headers)
       mock_request.expects(:call).returns(Nokogiri::XML response_xml).at_least(0)
       Azure.config.sql_database_authentication_mode = :management_certificate

--- a/test/unit/database/sql_database_server_service_test.rb
+++ b/test/unit/database/sql_database_server_service_test.rb
@@ -36,7 +36,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:request_path) { '/servers' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -94,7 +94,7 @@ describe 'Azure::SqlDatabaseManagementService' do
           :list_servers
         ).returns([sql_server])
 
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -122,7 +122,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:location) { 'West US' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           anything
@@ -168,7 +168,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:request_path) { '/servers' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -226,7 +226,7 @@ describe 'Azure::SqlDatabaseManagementService' do
           :list_servers
         ).returns([sql_server])
 
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           nil
@@ -254,7 +254,7 @@ describe 'Azure::SqlDatabaseManagementService' do
       let(:location) { 'West US' }
 
       before do
-        SqlManagementHttpRequest.stubs(:new).with(
+        Azure::BaseManagement::SqlManagementHttpRequest.stubs(:new).with(
           method,
           request_path,
           anything

--- a/test/unit/service/storage_service_test.rb
+++ b/test/unit/service/storage_service_test.rb
@@ -142,11 +142,12 @@ describe Azure::Service::StorageService do
     }
 
     let(:service_properties_uri) { URI.parse 'http://dummy.uri/service/properties' }
+    let(:service_properties_headers) { {"x-ms-version" => "2013-08-15"} }
 
     before do 
       Azure::Service::Serialization.stubs(:service_properties_from_xml).with(service_properties_xml).returns(service_properties)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:get, service_properties_uri).returns(response)
+      subject.stubs(:call).with(:get, service_properties_uri, nil, service_properties_headers).returns(response)
     end
 
     it "calls the service_properties_uri method to determine the correct uri" do
@@ -155,7 +156,7 @@ describe Azure::Service::StorageService do
     end
 
     it "gets the response from the HTTP API" do
-      subject.expects(:call).with(:get, service_properties_uri).returns(response)
+      subject.expects(:call).with(:get, service_properties_uri, nil, service_properties_headers).returns(response)
       subject.get_service_properties
     end
 
@@ -180,11 +181,12 @@ describe Azure::Service::StorageService do
     }
 
     let(:service_properties_uri) { URI.parse 'http://dummy.uri/service/properties' }
+    let(:service_properties_headers) { {"x-ms-version" => "2013-08-15"} }
 
     before do 
       Azure::Service::Serialization.stubs(:service_properties_to_xml).with(service_properties).returns(service_properties_xml)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml, service_properties_headers).returns(response)
     end
 
     it "calls the service_properties_uri method to determine the correct uri" do
@@ -193,7 +195,7 @@ describe Azure::Service::StorageService do
     end
 
     it "posts to the HTTP API" do
-      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml, service_properties_headers).returns(response)
       subject.set_service_properties service_properties
     end
 

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -28,7 +28,7 @@ describe Azure::StorageManagementService do
   }
   let(:response_body) {Nokogiri::XML response.body}
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
 
   describe "#list_storage_accounts" do

--- a/test/unit/storage_management/storage_management_service_test.rb
+++ b/test/unit/storage_management/storage_management_service_test.rb
@@ -33,7 +33,7 @@ describe Azure::StorageManagementService do
 
   describe "#list_storage_accounts" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 
@@ -56,7 +56,7 @@ describe Azure::StorageManagementService do
 
   describe "#get_storage_account" do
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
     }
 
@@ -105,14 +105,14 @@ describe Azure::StorageManagementService do
     end
 
     it "Create storage account return message if storage account exists of given name." do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       msg = subject.create_storage_account 'storage1'
       assert_match(/^Storage Account storage1 already exist.*/, msg)
     end
 
     it "Create storage account if storage account doesn't exists of given name." do
       Azure::StorageManagementService.any_instance.stubs(:get_storage_account).with('storage3').returns(false)
-      ManagementHttpRequest.any_instance.expects(:call).returns nil
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns nil
       subject.create_storage_account 'storage3'
     end
 
@@ -138,7 +138,7 @@ describe Azure::StorageManagementService do
     }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_request)
       mock_request.expects(:call).returns(response_body)
 
       Azure::StorageManagement::Serialization.stubs(:update_storage_account).returns(update_storage_account_req)
@@ -175,12 +175,12 @@ describe Azure::StorageManagementService do
     end
 
     it "updates the specified account" do
-      ManagementHttpRequest.stubs(:new).with(:put, "#{request_path}/storage2", update_storage_account_req).returns(update_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(:put, "#{request_path}/storage2", update_storage_account_req).returns(update_request)
       update_request.expects(:call).returns('')
 
       subject.update_storage_account 'storage2', options
 
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(updated_storage_account_mock_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(updated_storage_account_mock_request)
       updated_storage_account_mock_request.expects(:call).returns(updated_storage_account_response_body)
 
       accounts = subject.list_storage_accounts
@@ -216,7 +216,7 @@ describe Azure::StorageManagementService do
     }
 
     before {
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         :get, request_path, nil
       ).returns(get_account_mock_request)
       get_account_mock_request.expects(:call).returns(

--- a/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
+++ b/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
@@ -36,7 +36,7 @@ describe Azure::VirtualMachineImageManagementService do
   describe "#list_virtual_machine_images" do
     
     before {
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         request_path,
         nil

--- a/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
+++ b/test/unit/virtual_machine_image_management/virtual_machine_image_management_service_test.rb
@@ -30,7 +30,7 @@ describe Azure::VirtualMachineImageManagementService do
   let(:response_body) { Nokogiri::XML response.body }
 
   before{
-    Loggerx.expects(:puts).returns(nil).at_least(0)
+    Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
   }
   
   describe "#list_virtual_machine_images" do

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -265,4 +265,28 @@ describe Azure::VirtualMachineManagement::Serialization do
       assert_operator result.to_i, :<=, 65535
     end
   end
+  
+  describe "#role_to_xml" do
+    
+    before(:each) do
+      @params = { 
+          :certificate => { :fingerprint => "fingerprint" },
+          :vm_name => "aVMName", 
+          :image => "anImage" 
+      }
+      
+      @options = { 
+          :virtual_network_name => "aNetworkName", 
+          :subnet_name => "someSubnet", 
+          :storage_account_name => "storage", 
+          :vm_size => "Small" 
+      }
+    end
+    
+    it "should return a valid role containing a static vnet ip address" do
+      @options[:static_virtual_network_ipaddress] = "1.2.3.4"
+      result = subject.role_to_xml(@params, @options)
+      result.css('StaticVirtualNetworkIPAddress').text.must_equal "1.2.3.4"
+    end
+  end
 end

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -125,7 +125,8 @@ describe Azure::VirtualMachineManagement::Serialization do
         winrm_https_port: '5988',
         winrm_transport: ['http','https'],
         os_type: 'Windows',
-        existing_ports: ['5985']
+        existing_ports: ['5985'],
+        reserved_ip_name: "AnAwesomeIP"
       }
     end
 
@@ -173,6 +174,15 @@ describe Azure::VirtualMachineManagement::Serialization do
         media_link_uri = URI.parse(doc.css('Deployment RoleList OSVirtualHardDisk MediaLink').text)
         disk_time_name = /disk_(.*?)\.vhd/.match(media_link_uri.path).captures.first
         disk_time_name.must_equal now.strftime('%Y_%m_%d_%H_%M_%S_%L')
+      end
+    end
+
+    it 'returns a VirtualMachine object with the correct reserved IP' do
+      now = Time.now
+      Timecop.freeze(now) do
+        result = subject.deployment_to_xml params, options
+        doc = Nokogiri::XML(result)
+        doc.css('ReservedIPName').text.must_equal "AnAwesomeIP"
       end
     end
   end

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -272,21 +272,29 @@ describe Azure::VirtualMachineManagement::Serialization do
       @params = { 
           :certificate => { :fingerprint => "fingerprint" },
           :vm_name => "aVMName", 
-          :image => "anImage" 
+          :image => "anImage",
+          :vm_user => "nocturnal_flying_echolocating_mammal_man"
       }
       
       @options = { 
           :virtual_network_name => "aNetworkName", 
           :subnet_name => "someSubnet", 
           :storage_account_name => "storage", 
-          :vm_size => "Small" 
+          :vm_size => "Small",
+          :os_type => "Linux"
       }
     end
     
-    it "should return a valid role containing a static vnet ip address" do
+    it "should return a valid role containing a static vnet ip address if provided in options" do
       @options[:static_virtual_network_ipaddress] = "1.2.3.4"
       result = subject.role_to_xml(@params, @options)
       result.css('StaticVirtualNetworkIPAddress').text.must_equal "1.2.3.4"
+    end
+
+    it "should return a valid role containing a custom data section if provided in params" do
+      @params[:custom_data] = "blahblahblah"
+      result = subject.role_to_xml(@params, @options)
+      result.css('CustomData').text.must_equal "blahblahblah"
     end
   end
 end

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -165,7 +165,7 @@ describe Azure::VirtualMachineManagement::Serialization do
     let(:media_link) { 'https://sta.blob.managment.core.net/vhds/1234.vhd' }
     let(:lun) { 5 }
     before do
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'returns an xml for newly created data disk' do

--- a/test/unit/virtual_machine_management/serialization_test.rb
+++ b/test/unit/virtual_machine_management/serialization_test.rb
@@ -15,6 +15,8 @@
 require 'test_helper'
 
 describe Azure::VirtualMachineManagement::Serialization do
+  include Azure::Core::Utility
+  
   subject { Azure::VirtualMachineManagement::Serialization }
 
   let(:vm_xml) { Nokogiri::XML(Fixtures['virtual_machine']) }

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -422,7 +422,7 @@ describe Azure::VirtualMachineManagementService do
       exception = assert_raises(RuntimeError) do
         subject.add_role(windows_params, options)
       end
-      error_msg = 'No such file or directory -'
+      error_msg = 'No such file or directory'
       assert_match(/#{error_msg}/i, exception.message)
     end
 

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -22,7 +22,7 @@ describe Azure::VirtualMachineManagementService do
   end
 
   before do
-    Loggerx.stubs(:info).returns(nil)
+    Azure::Loggerx.stubs(:info).returns(nil)
   end
 
   let(:params)do
@@ -285,7 +285,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::CloudServiceManagementService.any_instance.stubs(:create_cloud_service)
       Azure::CloudServiceManagementService.any_instance.stubs(:upload_certificate)
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request = mock
       Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
@@ -415,7 +415,7 @@ describe Azure::VirtualMachineManagementService do
     before do
       Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       subject.class.send(:public, *subject.class.private_instance_methods)
-      Loggerx.expects(:puts).returns(nil).at_least(0)
+      Azure::Loggerx.expects(:puts).returns(nil).at_least(0)
     end
 
     it 'returns os type of given virtual machine image' do

--- a/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
+++ b/test/unit/virtual_machine_management/virtual_machine_management_service_test.rb
@@ -96,13 +96,13 @@ describe Azure::VirtualMachineManagementService do
     let(:virtual_networks_response_body) { Nokogiri::XML virtual_networks_response.body }
 
     before do
-      ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_cloud_service_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, request_path, nil).returns(mock_cloud_service_request)
       mock_cloud_service_request.expects(:call).returns(cloud_service_response_body)
-      ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-1/deploymentslots/production').returns(mock_virtual_machine_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-1/deploymentslots/production').returns(mock_virtual_machine_request)
       mock_virtual_machine_request.stubs(:warn=).returns(true).twice
-      ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-2/deploymentslots/production').returns(mock_virtual_machine_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/hostedservices/cloud-service-2/deploymentslots/production').returns(mock_virtual_machine_request)
       mock_virtual_machine_request.expects(:call).twice.returns(virtual_machine_response_body).returns(Nokogiri::XML  deployment_error_response.body)
-      ManagementHttpRequest.stubs(:new).with(method, '/services/networking/virtualnetwork', nil).returns(mock_virtual_network_request)
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(method, '/services/networking/virtualnetwork', nil).returns(mock_virtual_network_request)
     end
 
     it 'assembles a URI for the request' do
@@ -198,14 +198,14 @@ describe Azure::VirtualMachineManagementService do
     end
 
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         images_request_path,
         nil
       ).returns(mock_request)
       mock_request.expects(:call).returns(os_response_body)
       mock_request = mock
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         location_request_path,
         nil
@@ -215,7 +215,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::CloudServiceManagementService.any_instance.stubs(:upload_certificate)
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
       mock_request = mock
-      ManagementHttpRequest.expects(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
         anything,
         anything
@@ -269,14 +269,14 @@ describe Azure::VirtualMachineManagementService do
     end
 
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         images_request_path,
         nil
       ).returns(mock_request)
       mock_request.expects(:call).returns(os_response_body)
       mock_request = mock
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         method,
         location_request_path,
         nil
@@ -287,7 +287,7 @@ describe Azure::VirtualMachineManagementService do
       Azure::StorageManagementService.any_instance.stubs(:create_storage_account)
       Loggerx.expects(:puts).returns(nil).at_least(0)
       mock_request = mock
-      ManagementHttpRequest.expects(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.expects(:new).with(
         :post,
         anything,
         anything
@@ -413,7 +413,7 @@ describe Azure::VirtualMachineManagementService do
     let(:response_body) { Nokogiri::XML response.body }
 
     before do
-      ManagementHttpRequest.any_instance.expects(:call).returns response_body
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(:call).returns response_body
       subject.class.send(:public, *subject.class.private_instance_methods)
       Loggerx.expects(:puts).returns(nil).at_least(0)
     end

--- a/test/unit/vnet/serialization_test.rb
+++ b/test/unit/vnet/serialization_test.rb
@@ -93,7 +93,7 @@ describe Azure::VirtualNetworkManagement::Serialization do
 
   describe '#virtual_network_to_xml' do
     before do
-      ManagementHttpRequest.any_instance.expects(
+      Azure::BaseManagement::ManagementHttpRequest.any_instance.expects(
         :call
       ).returns(virtual_networks_xml)
     end

--- a/test/unit/vnet/virtual_network_management_service_test.rb
+++ b/test/unit/vnet/virtual_network_management_service_test.rb
@@ -56,7 +56,7 @@ describe Azure::VirtualNetworkManagementService do
 
   describe '#list_virtual_networks' do
     before do
-      ManagementHttpRequest.stubs(:new).with(
+      Azure::BaseManagement::ManagementHttpRequest.stubs(:new).with(
         getmethod,
         list_networks_path,
         nil


### PR DESCRIPTION
I am using the Azure gem in a project and had some wired problems defining a Location class. After some investigation I found out that the class clashes with the Azure::BaseManagement::Location class. This is because of the line include Azure::BaseManagement in lib/azure/base_management/base_management_service.rb. This is really bad as it messes with the root namespace. I removed the include and fixed all references. All tests are passing. I did the same with the Loggerx and the include of the core utils.

I also created a pull request in the official repo but no response until today...
